### PR TITLE
Update settings repo to new peril format

### DIFF
--- a/org/closed-prs.ts
+++ b/org/closed-prs.ts
@@ -2,22 +2,9 @@ import { schedule, danger, warn, fail, peril } from "danger"
 import { IncomingWebhook } from "@slack/client"
 import { PullRequest, Issues } from "github-webhook-event-types"
 
-const isJest = typeof jest !== "undefined"
-
-// Stores the parameter in a closure that can be invoked in tests.
-const storeRFC = (reason: string, closure: () => void | Promise<any>) =>
-  // We return a closure here so that the (promise is resolved|closure is invoked)
-  // during test time and not when we call rfc().
-  () => (closure instanceof Promise ? closure : Promise.resolve(closure()))
-
-// Either schedules the promise for execution via Danger, or invokes closure.
-const runRFC = (reason: string, closure: () => void | Promise<any>) =>
-  closure instanceof Promise ? schedule(closure) : closure()
-
-const rfc: any = isJest ? storeRFC : runRFC
-
+// Ping slack channels for related labels
 // https://github.com/artsy/artsy-danger/issues/33
-export const rfc33 = rfc("Ping slack channels for related labels", async () => {
+export default async () => {
   const pr = danger.github.pr
   // You can get the channel ID by opening slack in
   // the web inspector and looking at the channel name
@@ -51,4 +38,4 @@ export const rfc33 = rfc("Ping slack channels for related labels", async () => {
       ],
     })
   }
-})
+}

--- a/org/new-release.ts
+++ b/org/new-release.ts
@@ -2,22 +2,9 @@ import { schedule, danger, warn, fail, peril } from "danger"
 import { IncomingWebhook } from "@slack/client"
 import { Create } from "github-webhook-event-types"
 
-const isJest = typeof jest !== "undefined"
-
-// Stores the parameter in a closure that can be invoked in tests.
-const storeRFC = (reason: string, closure: () => void | Promise<any>) =>
-  // We return a closure here so that the (promise is resolved|closure is invoked)
-  // during test time and not when we call rfc().
-  () => (closure instanceof Promise ? closure : Promise.resolve(closure()))
-
-// Either schedules the promise for execution via Danger, or invokes closure.
-const runRFC = (reason: string, closure: () => void | Promise<any>) =>
-  closure instanceof Promise ? schedule(closure) : closure()
-
-const rfc: any = isJest ? storeRFC : runRFC
-
+// Note new tags inside a releases channel
 // https://github.com/artsy/artsy-danger/issues/33
-export const rfc53 = rfc("Note new tags inside a releases channel", async () => {
+export default async () => {
   const api = danger.github.api
   const create = (danger.github as any) as Create
 
@@ -42,4 +29,4 @@ export const rfc53 = rfc("Note new tags inside a releases channel", async () => 
       },
     ],
   })
-})
+}

--- a/tests/rfc_13.test.ts
+++ b/tests/rfc_13.test.ts
@@ -11,23 +11,20 @@ beforeEach(() => {
 
 it("warns when there's there's no assignee and no WIP in the title", () => {
   dm.danger.github = { pr: { title: "My Thing", assignee: null } }
-  rfc13().then(() => {
-    expect(dm.warn).toHaveBeenCalledWith(
-      "Please assign someone to merge this PR, and optionally include people who should review."
-    )
-  })
+  rfc13()
+  expect(dm.warn).toHaveBeenCalledWith(
+    "Please assign someone to merge this PR, and optionally include people who should review."
+  )
 })
 
 it("does not warn when there's there's no assignee and WIP in the title", () => {
   dm.danger.github = { pr: { title: "[WIP] My thing", assignee: null } }
-  rfc13().then(() => {
-    expect(dm.warn).not.toBeCalled()
-  })
+  rfc13()
+  expect(dm.warn).not.toBeCalled()
 })
 
 it("does not warn when there's there's an assignee", () => {
   dm.danger.github = { pr: { title: "My thing", assignee: {} } }
-  rfc13().then(() => {
-    expect(dm.warn).not.toBeCalled()
-  })
+  rfc13()
+  expect(dm.warn).not.toBeCalled()
 })

--- a/tests/rfc_33.test.ts
+++ b/tests/rfc_33.test.ts
@@ -10,7 +10,7 @@ jest.mock("@slack/client", () => ({
 
 import { IncomingWebhook } from "@slack/client"
 
-import { rfc33 } from "../org/closed-prs"
+import rfc33 from "../org/closed-prs"
 
 it("calls the issues API to get labels", () => {
   dm.danger = {

--- a/tests/rfc_5.test.ts
+++ b/tests/rfc_5.test.ts
@@ -10,14 +10,12 @@ beforeEach(() => {
 
 it("fails when there's no PR body", () => {
   dm.danger = { github: { pr: { body: "" } } }
-  return rfc5().then(() => {
-    expect(dm.fail).toHaveBeenCalledWith("Please add a description to your PR.")
-  })
+  rfc5()
+  expect(dm.fail).toHaveBeenCalledWith("Please add a description to your PR.")
 })
 
 it("does nothing when there's a PR body", () => {
   dm.danger = { github: { pr: { body: "Hello world" } } }
-  return rfc5().then(() => {
-    expect(dm.fail).not.toHaveBeenCalled()
-  })
+  rfc5()
+  expect(dm.fail).not.toHaveBeenCalled()
 })

--- a/tests/rfc_53.test.ts
+++ b/tests/rfc_53.test.ts
@@ -6,7 +6,7 @@ jest.mock("@slack/client", () => ({
 }))
 import { IncomingWebhook } from "@slack/client"
 
-import { rfc53 } from "../org/new-release"
+import rfc53 from "../org/new-release"
 
 it("ignores creates which aren't tags", async () => {
   dm.danger = {


### PR DESCRIPTION
Now that we're moving to peril-staging, we can use the new  default export feature of a Dangerfile - https://github.com/danger/peril/pull/247

This vastly simplifies each dangerfile, and makes testing basically the same as a normal JS file 👍 