### PR TITLE
Adds merge on green support to the Artsy org

### DIFF
--- a/org/markAsMergeOnGreen.ts
+++ b/org/markAsMergeOnGreen.ts
@@ -1,0 +1,75 @@
+import { danger } from "danger"
+import { IssueComment } from "github-webhook-event-types"
+
+// The shape of a label
+interface Label {
+  id: number
+  url: string
+  name: string
+  description: string
+  color: string
+  default: boolean
+}
+
+/** If a comment to an issue contains "Merge on Green", apply a label for it to be merged when green. */
+export const rfc10 = async (issueComment: IssueComment) => {
+  const issue = issueComment.issue
+  const comment = issueComment.comment
+  const api = danger.github.api
+
+  // Only look at PR issue comments, this isn't in the type system
+  if (!(issue as any).pull_request) {
+    console.error("Not a Pull Request")
+    return
+  }
+
+  // Don't do any work unless we have to
+  const keywords = ["merge on green", "merge on ci green"]
+  const match = keywords.find(k => comment.body.toLowerCase().includes(k))
+  if (!match) {
+    console.error(`Did not find any of the phrases in the comment: ${comment.body.toLocaleLowerCase()}`)
+    return
+  }
+
+  // Check to see if the label has already been set
+  if (issue.labels.find(l => l.name === "Merge On Green")) {
+    console.error("Already has Merge on Green")
+    return
+  }
+
+  const sender = comment.user
+  const username = sender.login
+  const org = issueComment.repository.owner.login
+
+  // Check for org access, so that some rando doesn't
+  // try to merge something without permission
+  try {
+    await api.orgs.checkMembership({ org, username })
+  } catch (error) {
+    // Someone does not have permission to force a merge
+    return console.error("Sender does not have permission to merge")
+  }
+
+  // Create or re-use an existing label
+  const owner = org
+  const repo = issueComment.repository.name
+  const existingLabels = await api.issues.getLabels({ owner, repo })
+  const mergeOnGreen = existingLabels.data.find((l: Label) => l.name == "Merge On Green")
+
+  // Create the label if it doesn't exist yet
+  if (!mergeOnGreen) {
+    const newLabel = await api.issues.createLabel({
+      owner,
+      repo,
+      name: "Merge On Green",
+      color: "247A38",
+      description: "A label to indicate that Peril should merge this PR when all statuses are green",
+    } as any)
+  }
+
+  // Then add the label
+  await api.issues.addLabels({ owner, repo, number: issue.number, labels: ["Merge On Green"] })
+  console.log("Updated the PR with a Merge on Green label")
+}
+
+export default rfc10

--- a/org/markAsMergeOnGreen.ts
+++ b/org/markAsMergeOnGreen.ts
@@ -19,7 +19,7 @@ export const rfc10 = async (issueComment: IssueComment) => {
 
   // Only look at PR issue comments, this isn't in the type system
   if (!(issue as any).pull_request) {
-    console.error("Not a Pull Request")
+    console.log("Not a Pull Request")
     return
   }
 
@@ -27,13 +27,13 @@ export const rfc10 = async (issueComment: IssueComment) => {
   const keywords = ["merge on green", "merge on ci green"]
   const match = keywords.find(k => comment.body.toLowerCase().includes(k))
   if (!match) {
-    console.error(`Did not find any of the phrases in the comment: ${comment.body.toLocaleLowerCase()}`)
+    console.log(`Did not find any of the phrases in the comment: ${comment.body.toLocaleLowerCase()}`)
     return
   }
 
   // Check to see if the label has already been set
   if (issue.labels.find(l => l.name === "Merge On Green")) {
-    console.error("Already has Merge on Green")
+    console.log("Already has Merge on Green")
     return
   }
 
@@ -47,7 +47,7 @@ export const rfc10 = async (issueComment: IssueComment) => {
     await api.orgs.checkMembership({ org, username })
   } catch (error) {
     // Someone does not have permission to force a merge
-    return console.error("Sender does not have permission to merge")
+    return console.log("Sender does not have permission to merge")
   }
 
   // Create or re-use an existing label

--- a/org/mergeOnGreen.ts
+++ b/org/mergeOnGreen.ts
@@ -1,0 +1,44 @@
+import { schedule, danger, markdown } from "danger"
+import { Status } from "github-webhook-event-types"
+import { LabelLabel } from "github-webhook-event-types/source/Label"
+
+export const rfc10 = async (status: Status) => {
+  const api = danger.github.api
+
+  if (status.state !== "success") {
+    return console.error(
+      `Not a successful state (note that you can define state in the settings.json) - got ${status.state}`
+    )
+  }
+
+  // Check to see if all other statuses on the same commit are also green. E.g. is this the last green.
+  const owner = status.repository.owner.login
+  const repo = status.repository.name
+  const allGreen = await api.repos.getCombinedStatusForRef({ owner, repo, ref: status.commit.sha })
+  if (allGreen.data.state !== "success") {
+    return console.error("Not all statuses are green")
+  }
+
+  // See https://github.com/maintainers/early-access-feedback/issues/114 for more context on getting a PR from a SHA
+  const repoString = status.repository.full_name
+  const searchResponse = await api.search.issues({ q: `${status.commit.sha} type:pr is:open repo:${repoString}` })
+
+  // https://developer.github.com/v3/search/#search-issues
+  const prsWithCommit = searchResponse.data.items.map((i: any) => i.number) as number[]
+  for (const number of prsWithCommit) {
+    // Get the PR labels
+    const issue = await api.issues.get({ owner, repo, number })
+
+    // Get the PR combined status
+    const mergeLabel = issue.data.labels.find((l: LabelLabel) => l.name === "Merge On Green")
+    if (!mergeLabel) {
+      return console.error("PR does not have Merge on Green")
+    }
+
+    // Merge the PR
+    await api.pullRequests.merge({ owner, repo, number, commit_title: "Merged by Peril" })
+    console.log(`Merged Pull Request ${number}`)
+  }
+}
+
+export default rfc10

--- a/org/mergeOnGreen.ts
+++ b/org/mergeOnGreen.ts
@@ -6,7 +6,7 @@ export const rfc10 = async (status: Status) => {
   const api = danger.github.api
 
   if (status.state !== "success") {
-    return console.error(
+    return console.log(
       `Not a successful state (note that you can define state in the settings.json) - got ${status.state}`
     )
   }
@@ -16,7 +16,7 @@ export const rfc10 = async (status: Status) => {
   const repo = status.repository.name
   const allGreen = await api.repos.getCombinedStatusForRef({ owner, repo, ref: status.commit.sha })
   if (allGreen.data.state !== "success") {
-    return console.error("Not all statuses are green")
+    return console.log("Not all statuses are green")
   }
 
   // See https://github.com/maintainers/early-access-feedback/issues/114 for more context on getting a PR from a SHA
@@ -32,7 +32,7 @@ export const rfc10 = async (status: Status) => {
     // Get the PR combined status
     const mergeLabel = issue.data.labels.find((l: LabelLabel) => l.name === "Merge On Green")
     if (!mergeLabel) {
-      return console.error("PR does not have Merge on Green")
+      return console.log("PR does not have Merge on Green")
     }
 
     // Merge the PR

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -6,10 +6,12 @@
     "modules": ["danger-plugin-spellcheck", "danger-plugin-yarn", "@slack/client"]
   },
   "rules": {
+    "create": "artsy/artsy-danger@org/new-release.ts",
     "pull_request": "artsy/artsy-danger@org/all-prs.ts",
     "pull_request.closed": "artsy/artsy-danger@org/closed-prs.ts",
     "issues.opened": "artsy/artsy-danger@danger/new-rfc.ts",
-    "create": "artsy/artsy-danger@org/new-release.ts"
+    "issue_comment": "artsy/artsy-danger@org/markAsMergeOnGreen.ts",
+    "status.success": "artsy/artsy-danger@org/mergeOnGreen.ts"
   },
   "repos": {
     "artsy/reaction": {

--- a/tests/rfc_10.test.ts
+++ b/tests/rfc_10.test.ts
@@ -31,7 +31,6 @@ beforeEach(() => {
     },
   }
   ;(global as any).console = {
-    error: jest.fn(),
     log: jest.fn(),
   }
 })
@@ -39,12 +38,12 @@ beforeEach(() => {
 describe("for adding the label", () => {
   it("bails when the comment is not on a pr", async () => {
     await markAsMergeOnGreen({ issue: {} } as any)
-    expect(console.error).toBeCalledWith("Not a Pull Request")
+    expect(console.log).toBeCalledWith("Not a Pull Request")
   })
 
   it("bails when the issue body doesn't contain the key words", async () => {
     await markAsMergeOnGreen({ comment: { body: "Hi" }, issue: { pull_request: {} } } as any)
-    expect(console.error).toBeCalledWith(expect.stringMatching("Did not find"))
+    expect(console.log).toBeCalledWith(expect.stringMatching("Did not find"))
   })
 
   it("bails when the issue already has merge on green", async () => {
@@ -52,7 +51,7 @@ describe("for adding the label", () => {
       comment: { body: "Merge on green" },
       issue: { labels: [{ name: "Merge On Green" }], pull_request: {} },
     } as any)
-    expect(console.error).toBeCalledWith("Already has Merge on Green")
+    expect(console.log).toBeCalledWith("Already has Merge on Green")
   })
 
   it("creates the label when the label doesn't exist on the repo", async () => {
@@ -96,7 +95,7 @@ describe("for adding the label", () => {
 describe("for handling merging when green", () => {
   it("bails when its not a success", async () => {
     await mergeOnGreen({ state: "fail" } as any)
-    expect(console.error).toBeCalled()
+    expect(console.log).toBeCalled()
   })
 
   it("bails when the whole status is not a success", async () => {
@@ -110,7 +109,7 @@ describe("for handling merging when green", () => {
       commit: { sha: "123abc" },
     } as any)
 
-    expect(console.error).toBeCalledWith("Not all statuses are green")
+    expect(console.log).toBeCalledWith("Not all statuses are green")
   })
 
   it("does nothing when the PR does not have merge on green ", async () => {
@@ -133,7 +132,7 @@ describe("for handling merging when green", () => {
       commit: { sha: "123abc" },
     } as any)
 
-    expect(console.error).toBeCalledWith("PR does not have Merge on Green")
+    expect(console.log).toBeCalledWith("PR does not have Merge on Green")
   })
 
   it("triggers a PR merge when there is a merge on green label ", async () => {

--- a/tests/rfc_10.test.ts
+++ b/tests/rfc_10.test.ts
@@ -1,0 +1,166 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import mergeOnGreen from "../org/mergeOnGreen"
+import markAsMergeOnGreen from "../org/markAsMergeOnGreen"
+
+beforeEach(() => {
+  dm.danger = {
+    github: {
+      api: {
+        repos: {
+          getCombinedStatusForRef: jest.fn(),
+        },
+        search: {
+          issues: jest.fn(),
+        },
+        issues: {
+          get: jest.fn(),
+          getLabels: jest.fn(),
+          createLabel: jest.fn(),
+          addLabels: jest.fn(),
+        },
+        pullRequests: {
+          merge: jest.fn(),
+        },
+        orgs: {
+          checkMembership: jest.fn(),
+        },
+      },
+    },
+  }
+  ;(global as any).console = {
+    error: jest.fn(),
+    log: jest.fn(),
+  }
+})
+
+describe("for adding the label", () => {
+  it("bails when the comment is not on a pr", async () => {
+    await markAsMergeOnGreen({ issue: {} } as any)
+    expect(console.error).toBeCalledWith("Not a Pull Request")
+  })
+
+  it("bails when the issue body doesn't contain the key words", async () => {
+    await markAsMergeOnGreen({ comment: { body: "Hi" }, issue: { pull_request: {} } } as any)
+    expect(console.error).toBeCalledWith(expect.stringMatching("Did not find"))
+  })
+
+  it("bails when the issue already has merge on green", async () => {
+    await markAsMergeOnGreen({
+      comment: { body: "Merge on green" },
+      issue: { labels: [{ name: "Merge On Green" }], pull_request: {} },
+    } as any)
+    expect(console.error).toBeCalledWith("Already has Merge on Green")
+  })
+
+  it("creates the label when the label doesn't exist on the repo", async () => {
+    dm.danger.github.api.orgs.checkMembership.mockReturnValueOnce(Promise.resolve({ data: {} }))
+
+    dm.danger.github.api.issues.getLabels.mockReturnValueOnce(Promise.resolve({ data: [] }))
+
+    await markAsMergeOnGreen({
+      comment: {
+        body: "Merge on green",
+        user: { sender: { login: "orta" } },
+      },
+      issue: { labels: [], pull_request: {} },
+      repository: { owner: { login: "danger" } },
+    } as any)
+
+    expect(dm.danger.github.api.issues.createLabel).toBeCalled()
+    expect(dm.danger.github.api.issues.addLabels).toBeCalled()
+  })
+
+  it("use the existing label when the label is on the repo", async () => {
+    dm.danger.github.api.orgs.checkMembership.mockReturnValueOnce(Promise.resolve({ data: {} }))
+
+    // When we ask for labels, it returns the the merge on green one
+    dm.danger.github.api.issues.getLabels.mockReturnValueOnce(Promise.resolve({ data: [{ name: "Merge On Green" }] }))
+
+    await markAsMergeOnGreen({
+      comment: {
+        body: "Merge on green",
+        user: { sender: { login: "orta" } },
+      },
+      issue: { labels: [], pull_request: {} },
+      repository: { owner: { login: "danger" } },
+    } as any)
+
+    expect(dm.danger.github.api.issues.createLabel).not.toBeCalled()
+    expect(dm.danger.github.api.issues.addLabels).toBeCalled()
+  })
+})
+
+describe("for handling merging when green", () => {
+  it("bails when its not a success", async () => {
+    await mergeOnGreen({ state: "fail" } as any)
+    expect(console.error).toBeCalled()
+  })
+
+  it("bails when the whole status is not a success", async () => {
+    dm.danger.github.api.repos.getCombinedStatusForRef.mockReturnValueOnce(
+      Promise.resolve({ data: { state: "failed " } })
+    )
+
+    await mergeOnGreen({
+      state: "success",
+      repository: { owner: { login: "danger" }, name: "doggo" },
+      commit: { sha: "123abc" },
+    } as any)
+
+    expect(console.error).toBeCalledWith("Not all statuses are green")
+  })
+
+  it("does nothing when the PR does not have merge on green ", async () => {
+    // Has the right status
+    dm.danger.github.api.repos.getCombinedStatusForRef.mockReturnValueOnce(
+      Promise.resolve({ data: { state: "success" } })
+    )
+
+    // Gets a corresponding issue
+    dm.danger.github.api.search.issues.mockReturnValueOnce(Promise.resolve({ data: { items: [{ number: 1 }] } }))
+
+    // Returns an issue without the merge on green label
+    dm.danger.github.api.issues.get.mockReturnValueOnce(
+      Promise.resolve({ data: { labels: [{ name: "Dog Snoozer" }] } })
+    )
+
+    await mergeOnGreen({
+      state: "success",
+      repository: { owner: { login: "danger" }, name: "doggo" },
+      commit: { sha: "123abc" },
+    } as any)
+
+    expect(console.error).toBeCalledWith("PR does not have Merge on Green")
+  })
+
+  it("triggers a PR merge when there is a merge on green label ", async () => {
+    // Has the right status
+    dm.danger.github.api.repos.getCombinedStatusForRef.mockReturnValueOnce(
+      Promise.resolve({ data: { state: "success" } })
+    )
+
+    // Gets a corresponding issue
+    dm.danger.github.api.search.issues.mockReturnValueOnce(Promise.resolve({ data: { items: [{ number: 1 }] } }))
+
+    // Returns an issue without the merge on green label
+    dm.danger.github.api.issues.get.mockReturnValueOnce(
+      Promise.resolve({ data: { labels: [{ name: "Merge On Green" }] } })
+    )
+
+    await mergeOnGreen({
+      state: "success",
+      repository: { owner: { login: "danger" }, name: "doggo" },
+      commit: { sha: "123abc" },
+    } as any)
+
+    expect(dm.danger.github.api.pullRequests.merge).toBeCalledWith({
+      commit_title: "Merged by Peril",
+      number: 1,
+      owner: "danger",
+      repo: "doggo",
+    })
+  })
+})


### PR DESCRIPTION
Fixes #10 - Well tested.

Adds merge on green - something I've been using for the last [three weeks on danger-js](https://github.com/danger/danger-js/pulls?q=is%3Apr+is%3Aclosed+label%3A%22Merge+On+Green%22) successfully. 