### PR TITLE
Updates the RFC code to handle the new async version inside a sandbox

### DIFF
--- a/danger/new-rfc.ts
+++ b/danger/new-rfc.ts
@@ -1,9 +1,8 @@
 import { danger, peril } from "danger"
 import { Issues } from "github-webhook-event-types"
 
-export const check = () => {
-  const gh = (danger.github as any) as Issues
-  const issue = gh.issue
+export default async (issues: Issues) => {
+  const issue = issues.issue
 
   const slackify = (text: string) => ({
     unfurl_links: false,
@@ -20,13 +19,12 @@ export const check = () => {
   })
 
   if (issue.title.includes("RFC:") || issue.title.includes("[RFC]")) {
-    peril.runTask("slack-dev-channel", "in 5 minutes", slackify("🎉: A new RFC has been published."))
-    peril.runTask("slack-dev-channel", "in 3 days", slackify("🕰: A new RFC was published 3 days ago."))
-    peril.runTask("slack-dev-channel", "in 7 days", slackify("🕰: A new RFC is ready to be resolved."))
-  }
-}
+    console.log("Triggering slack notifications")
 
-const isJest = typeof jest !== "undefined"
-if (!isJest) {
-  check()
+    await peril.runTask("slack-dev-channel", "in 5 minutes", slackify("🎉: A new RFC has been published."))
+    await peril.runTask("slack-dev-channel", "in 3 days", slackify("🕰: A new RFC was published 3 days ago."))
+    await peril.runTask("slack-dev-channel", "in 7 days", slackify("🕰: A new RFC is ready to be resolved."))
+
+    console.log("Triggered slack notifications")
+  }
 }

--- a/org/new-release.ts
+++ b/org/new-release.ts
@@ -3,19 +3,14 @@ import { IncomingWebhook } from "@slack/client"
 import { Create } from "github-webhook-event-types"
 
 // Note new tags inside a releases channel
-// https://github.com/artsy/artsy-danger/issues/33
-export default async () => {
-  const api = danger.github.api
-  const create = (danger.github as any) as Create
-
-  // Only make announcements for tags
-  if (create.ref_type !== "tag") {
-    return
+// https://github.com/artsy/artsy-danger/issues/40
+//
+export default async (create: Create) => {
+  if (!peril.env.SLACK_RFC_WEBHOOK_URL) {
+    throw new Error("There is no slack webhook env var set up")
   }
 
-  var url = peril.env.SLACK_RFC_WEBHOOK_URL || ""
-  var webhook = new IncomingWebhook(url)
-
+  var webhook = new IncomingWebhook(peril.env.SLACK_RFC_WEBHOOK_URL)
   await webhook.send({
     unfurl_links: false,
     channel: "CA3LTRT0T",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,14 @@
   "scripts": {
     "precommit": "lint-staged"
   },
-  "dependencies": {},
+  "dependencies": {
+    "node-fetch": "^2.1.2"
+  },
   "devDependencies": {
     "@slack/client": "^4.2.0",
     "@types/jest": "^22.2.3",
     "@types/node": "^10.0.0",
+    "@types/node-fetch": "^1.6.9",
     "danger": "^3.7.14",
     "danger-plugin-spellcheck": "^1.2.2",
     "danger-plugin-yarn": "^1.3.0",

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -6,7 +6,7 @@
     "modules": ["danger-plugin-spellcheck", "danger-plugin-yarn", "@slack/client"]
   },
   "rules": {
-    "create": "artsy/artsy-danger@org/new-release.ts",
+    "create (ref_type == tag)": "artsy/artsy-danger@org/new-release.ts",
     "pull_request": "artsy/artsy-danger@org/all-prs.ts",
     "pull_request.closed": "artsy/artsy-danger@org/closed-prs.ts",
     "issues.opened": "artsy/artsy-danger@danger/new-rfc.ts",

--- a/tests/rfc_40.test.ts
+++ b/tests/rfc_40.test.ts
@@ -1,53 +1,40 @@
-jest.mock("danger", () => jest.fn())
-import * as danger from "danger"
-const dm = danger as any
+jest.mock("danger", () => ({ peril: { runTask: jest.fn() } }))
+import { peril } from "danger"
 
-import { check } from "../danger/new-rfc"
+import check from "../danger/new-rfc"
 
-it("ignores issues which aren't RFCs", () => {
-  dm.danger = {
-    github: {
-      issue: {
-        title: "This awesome PR",
-        html_url: "123",
-        user: {
-          login: "orta",
-          avatar_url: "https://123.com",
-        },
+it("ignores issues which aren't RFCs", async () => {
+  const issues: any = {
+    issue: {
+      title: "This awesome PR",
+      html_url: "123",
+      user: {
+        login: "orta",
+        avatar_url: "https://123.com",
       },
     },
   }
 
-  dm.peril = {
-    runTask: jest.fn(),
-  }
+  await check(issues)
 
-  check()
-
-  expect(dm.peril.runTask).not.toBeCalled()
+  expect(peril.runTask).not.toBeCalled()
 })
 
-it("Triggers tasks when RFC is in the title", () => {
-  dm.danger = {
-    github: {
-      issue: {
-        title: "[RFC] Let's make a change",
-        html_url: "123",
-        user: {
-          login: "orta",
-          avatar_url: "https://123.com",
-        },
+it("Triggers tasks when RFC is in the title", async () => {
+  const issues: any = {
+    issue: {
+      title: "[RFC] Let's make a change",
+      html_url: "123",
+      user: {
+        login: "orta",
+        avatar_url: "https://123.com",
       },
     },
   }
 
-  dm.peril = {
-    runTask: jest.fn(),
-  }
+  await check(issues)
 
-  check()
-
-  expect(dm.peril.runTask).toHaveBeenCalledWith("slack-dev-channel", "in 5 minutes", expect.anything())
-  expect(dm.peril.runTask).toHaveBeenCalledWith("slack-dev-channel", "in 3 days", expect.anything())
-  expect(dm.peril.runTask).toHaveBeenCalledWith("slack-dev-channel", "in 7 days", expect.anything())
+  expect(peril.runTask).toHaveBeenCalledWith("slack-dev-channel", "in 5 minutes", expect.anything())
+  expect(peril.runTask).toHaveBeenCalledWith("slack-dev-channel", "in 3 days", expect.anything())
+  expect(peril.runTask).toHaveBeenCalledWith("slack-dev-channel", "in 7 days", expect.anything())
 })

--- a/tests/rfc_53.test.ts
+++ b/tests/rfc_53.test.ts
@@ -8,36 +8,18 @@ import { IncomingWebhook } from "@slack/client"
 
 import rfc53 from "../org/new-release"
 
-it("ignores creates which aren't tags", async () => {
-  dm.danger = {
-    github: {
-      ref_type: "branch",
-    },
-  }
-
-  dm.peril = {
-    env: { SLACK_RFC_WEBHOOK_URL: "https://123.com/api" },
-  }
-
-  await rfc53()
-
-  expect(IncomingWebhook).not.toBeCalled()
-})
-
 it("sends a webhook for creates which are tags", async () => {
   IncomingWebhook.prototype.send = jest.fn()
 
-  dm.danger = {
-    github: {
-      ref_type: "tag",
-      ref: "v1.4.0",
-      repository: {
-        name: "eigen",
-      },
-      sender: {
-        login: "Yuki",
-        avatar_url: "http://my.avatar.com",
-      },
+  const webhook = {
+    ref_type: "tag",
+    ref: "v1.4.0",
+    repository: {
+      name: "eigen",
+    },
+    sender: {
+      login: "Yuki",
+      avatar_url: "http://my.avatar.com",
     },
   }
 
@@ -45,7 +27,7 @@ it("sends a webhook for creates which are tags", async () => {
     env: { SLACK_RFC_WEBHOOK_URL: "https://123.com/api" },
   }
 
-  await rfc53()
+  await rfc53(webhook as any)
 
   expect(IncomingWebhook.prototype.send).toHaveBeenCalledWith({
     attachments: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -94,6 +94,12 @@
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/@types/loglevel/-/loglevel-1.5.3.tgz#adfce55383edc5998a2170ad581b3e23d6adb5b8"
 
+"@types/node-fetch@^1.6.9":
+  version "1.6.9"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-1.6.9.tgz#a750fb0f4cf2960bf72b462e4c86908022dd69c5"
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*", "@types/node@^10.0.0":
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.0.0.tgz#c40f8e07dce607d3ef25a626b93a6a7cdcf97881"


### PR DESCRIPTION
- `peril.runTask` is now running on a different server than the code is being executed on, so it needs to be switched into an async task.
- Moved more of the event based Dangerfiles to use `export default` for their runtime
- Adds node-fetch to the types