### PR TITLE
Updates the changelog check to include a sha instead of master

### DIFF
--- a/org/all-prs.ts
+++ b/org/all-prs.ts
@@ -64,7 +64,7 @@ export const rfc16 = async () => {
 
   // Get all the files in the root folder of the repo
   // e.g. https://api.github.com/repos/artsy/eigen/git/trees/master
-  const getContentParams = { owner: pr.head.user.login, repo: pr.head.repo.name, sha: "master" }
+  const getContentParams = { owner: pr.base.user.login, repo: pr.base.repo.name, tree_sha: pr.base.sha } as any
   const rootContents: any = await danger.github.api.gitdata.getTree(getContentParams)
 
   const hasChangelog = rootContents.data.tree.find((file: { path: string }) => changelogs.includes(file.path))

--- a/tests/rfc_16.test.ts
+++ b/tests/rfc_16.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 })
 
 const pr = {
-  head: {
+  base: {
     user: {
       login: "danger",
     },


### PR DESCRIPTION
Looks like the GitHub API wants you to use [tree SHAs](https://developer.github.com/v3/git/trees/#get-a-tree), not branches for file tree lookups. The RFC now uses the base merge sha (and base ref for everything else) to check if a changelog exists on the other repo.

Should fix https://github.com/artsy/diffusion/runs/2579570 on https://github.com/artsy/diffusion/pull/107