### PR TITLE
Adds a check for the current year to the license checker, and avoids forks

### DIFF
--- a/tasks/daily-license-check.ts
+++ b/tasks/daily-license-check.ts
@@ -13,12 +13,18 @@ export default async () => {
   for (const repo of repos) {
     console.log(`Grabbing ${org}/${repo.name}'s license`)
     const slug = `${org}/${repo.name}`
+    // Skip forks
+    if (repo.fork) {
+      continue
+    }
 
     try {
       const { data: contents } = await api.repos.getContent({ owner: org, repo: repo.name, path: "LICENSE" })
       const license = Buffer.from(contents.content, "base64").toString("utf8")
 
-      if (!license.includes(year)) {
+      // Skip repos that haven't been updated this year
+      const updatedThisYear = repo.pushed_at && repo.pushed_at.includes(year)
+      if (updatedThisYear && !license.includes(year)) {
         // Say that it needs changing
         noThisYear.push(`[${slug}](https://github.com/${slug})`)
       }


### PR DESCRIPTION
We want to reduce the number of false-positives in https://github.com/artsy/potential/issues/157 - this means only repos we own and repos updated this year get included.