### PR TITLE
Allows the CHANGELOG check to be skipped via #trivial

### DIFF
--- a/org/all-prs.ts
+++ b/org/all-prs.ts
@@ -59,6 +59,9 @@ export const rfc13 = () => {
 // https://github.com/artsy/peril-settings/issues/16
 export const rfc16 = async () => {
   const pr = danger.github.pr
+  if (pr.body.includes("#trivial")) {
+    return
+  }
   const changelogs = ["CHANGELOG.md", "changelog.md", "CHANGELOG.yml"]
   const isOpen = danger.github.pr.state === "open"
 
@@ -75,7 +78,9 @@ export const rfc16 = async () => {
     const hasChangelogChanges = files.find(file => changelogs.includes(file))
 
     if (hasCodeChanges && !hasChangelogChanges) {
-      warn("It looks like code was changed without adding anything to the Changelog")
+      warn(
+        "It looks like code was changed without adding anything to the Changelog.<br/>You can add #trivial in the PR body to skip the check."
+      )
     }
   }
 }

--- a/tests/rfc_16.test.ts
+++ b/tests/rfc_16.test.ts
@@ -19,6 +19,7 @@ const pr = {
     },
   },
   state: "open",
+  body: "Hello World",
 }
 
 it("warns when code has changed but no changelog entry was made", () => {
@@ -101,6 +102,24 @@ it("does not warns with a closed PR", () => {
       },
     },
     pr: { ...pr, state: "closed" },
+  }
+  dm.danger.git = {
+    modified_files: ["src/index.html"],
+    created_files: [],
+  }
+  return rfc16().then(() => {
+    expect(dm.warn).not.toBeCalled()
+  })
+})
+
+it("is skipped via #trivial", () => {
+  dm.danger.github = {
+    api: {
+      gitdata: {
+        getTree: () => Promise.resolve({ data: { tree: [{ path: "code.js" }, { path: "CHANGELOG.md" }] } }),
+      },
+    },
+    pr: { ...pr, body: "Skip this, #trivial" },
   }
   dm.danger.git = {
     modified_files: ["src/index.html"],


### PR DESCRIPTION
Convention in mobile repos is to allow skipping the changelog check ( [eigen](https://github.com/artsy/eigen/blob/master/Dangerfile#L4-L7) / [emission](https://github.com/artsy/emission/blob/master/dangerfile.ts#L18-L21) ) - this allows Peril to also have the same rules.