### PR TITLE
Include PR number in commit title when merging on green

### DIFF
--- a/org/mergeOnGreen.ts
+++ b/org/mergeOnGreen.ts
@@ -36,7 +36,7 @@ export const rfc10 = async (status: Status) => {
     }
 
     // Merge the PR
-    await api.pullRequests.merge({ owner, repo, number, commit_title: "Merged by Peril" })
+    await api.pullRequests.merge({ owner, repo, number, commit_title: `Merge pull request #${number} by Peril` })
     console.log(`Merged Pull Request ${number}`)
   }
 }

--- a/tests/rfc_10.test.ts
+++ b/tests/rfc_10.test.ts
@@ -156,7 +156,7 @@ describe("for handling merging when green", () => {
     } as any)
 
     expect(dm.danger.github.api.pullRequests.merge).toBeCalledWith({
-      commit_title: "Merged by Peril",
+      commit_title: "Merge pull request #1 by Peril",
       number: 1,
       owner: "danger",
       repo: "doggo",


### PR DESCRIPTION
This updates the tense and format of merge commits to match Github's. Including the PR # is helpful because Github will auto-link that. I'd ideally like to include the `... from <repo>/<branch>` part as well, but it wasn't immediately obvious how to determine this correctly from Github's API response.

Incidentally, matching Github's format will allow some of our projects' automated release emails to better identify the PRs corresponding to commits.