### PR TITLE
Add Volt to Peril repo

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -23,6 +23,9 @@
     },
     "artsy/exchange": {
       "pull_request": "artsy/exchange@dangerfile.ts"
+    },
+    "artsy/volt": {
+      "pull_request": "artsy/volt@dangerfile.ts"
     }
   },
   "tasks": {


### PR DESCRIPTION
We want to just use Peril instead of both Danger ruby and Peril in Volt.