### PR TITLE
Allows a human to set an RFC tab and have Peril work with it

### DIFF
--- a/org/rfc/addRFCToNewIssues.ts
+++ b/org/rfc/addRFCToNewIssues.ts
@@ -1,0 +1,27 @@
+import { danger } from "danger"
+import { Issues } from "github-webhook-event-types"
+
+/**
+ * When an an issue/PR is created, check to see if the title includes
+ * RFC, if it does - then add (or create) the label "RFC".
+ */
+export default async (issues: Issues) => {
+  const issue = issues.issue
+
+  if (issue.title.includes("RFC:") || issue.title.includes("[RFC]")) {
+    // Marks it as an RFC
+    console.log("Adding label to the issue")
+    await danger.github.utils.createOrAddLabel(
+      {
+        name: "RFC",
+        color: "053a68",
+        description: "Indicates that this PR is a Request For Comments",
+      },
+      {
+        owner: issues.repository.owner.login,
+        repo: issues.repository.name,
+        id: issue.number,
+      }
+    )
+  }
+}

--- a/org/rfc/scheduleRFCsForLabels.ts
+++ b/org/rfc/scheduleRFCsForLabels.ts
@@ -1,5 +1,10 @@
-import { peril, danger } from "danger"
+import { peril } from "danger"
 import { Issues } from "github-webhook-event-types"
+
+/**
+ * When an issue has been labelled RFC, then trigger the scheduler
+ * to send reminders about the issue into our slack.
+ */
 
 export default async (issues: Issues) => {
   const issue = issues.issue
@@ -18,23 +23,10 @@ export default async (issues: Issues) => {
     ],
   })
 
-  if (issue.title.includes("RFC:") || issue.title.includes("[RFC]")) {
-    // Marks it as an RFC
-    console.log("Adding label to the issue")
-    await danger.github.utils.createOrAddLabel(
-      {
-        name: "RFC",
-        color: "053a68",
-        description: "Indicates that this PR is a Request For Comments",
-      },
-      {
-        owner: issues.repository.owner.login,
-        repo: issues.repository.name,
-        id: issue.number,
-      }
-    )
-
+  const rfc = issue.labels.find(l => l.name === "RFC")
+  if (rfc) {
     console.log("Triggering slack notifications")
+
     await peril.runTask("slack-dev-channel", "in 5 minutes", slackify("🎉: A new RFC has been published."))
     await peril.runTask("slack-dev-channel", "in 3 days", slackify("🕰: A new RFC was published 3 days ago."))
     await peril.runTask("slack-dev-channel", "in 7 days", slackify("🕰: A new RFC is ready to be resolved."))

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "jest": {
     "transform": {
-      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(.test)\\.(ts|tsx)$",
     "moduleFileExtensions": [

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -6,11 +6,16 @@
     "ignored_repos": ["artsy/looker", "artsy/clouds", "artsy/design", "artsy/hokusai"]
   },
   "rules": {
+    // Keep a list of all deployments in slack
     "create (ref_type == tag)": "org/newRelease.ts",
+    // Jira integration
     //  "pull_request": ["org/all-prs.ts", "org/jira/pr.ts"],
     "pull_request": "org/allPRs.ts",
     "pull_request.closed": "org/closedPRs.ts",
-    "issues.opened": "danger/newRFC.ts",
+    // The RFC process
+    "issues.opened": "rfc/addRFCToNewIssues.ts",
+    "issues.labeled": "rfc/scheduleRFCsForLabels.ts",
+    // Merge on Green
     "issue_comment": "org/markAsMergeOnGreen.ts",
     "status.success": "org/mergeOnGreen.ts"
   },


### PR DESCRIPTION
Allows a human to set the label on an issue (in the case like 
https://github.com/artsy/README/issues/49 ) where I forgot to include RFC in the title when the issue was created. 

This allows anyone to set up and RFC process with just the label.