### PR TITLE
Support requests for merge on green behavior from a Pull Request review

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/danger/peril/master/peril-settings-json.schema",
-
   "settings": {
     "ignored_repos": ["artsy/looker", "artsy/clouds", "artsy/design", "artsy/hokusai"],
     "disable_github_check": true
@@ -16,7 +15,8 @@
     "issues.labeled": "org/rfc/scheduleRFCsForLabels.ts",
     // Merge on Green
     "issue_comment": "org/markAsMergeOnGreen.ts",
-    "status.success": "org/mergeOnGreen.ts"
+    "status.success": "org/mergeOnGreen.ts",
+    "pull_request_review": "org/markAsMergeOnGreen.ts"
   },
   "repos": {
     "artsy/reaction": {


### PR DESCRIPTION
Our organization's Peril settings support marking a Pull Request for an automated merge once commit statuses pass when requested from a comment on the Pull Request. This commit updates our Peril settings to also respond to the body of a submitted Pull Request Review, if provided.

The `org/markAsMergeOnGreen` rule currently supports a match against [IssueComment][issue-comment-event] GitHub webhook events. This commit updates the rule to support [PullRequestReview][pr-review-event] GitHub webhook events as well.

[pr-review-event]: https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
[issue-comment-event]: https://developer.github.com/v3/activity/events/types/#issuecommentevent

Addresses https://github.com/artsy/peril-settings/issues/81