### PR TITLE
Adds a check for PRs on Metaphysics that production is up-to-date with staging for dependent repos

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/jira-client": "^6.4.0",
     "@types/node": "^10.12.9",
     "@types/node-fetch": "^2.1.3",
+    "aws-sdk": "^2.382.0",
     "danger": "^6.1.4",
     "danger-plugin-spellcheck": "^1.2.3",
     "danger-plugin-yarn": "^1.3.0",

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -19,6 +19,9 @@
     "pull_request_review": "org/markAsMergeOnGreen.ts"
   },
   "repos": {
+    "artsy/metaphysics": {
+      "pull_request": "artsy/peril-settings@upstream/metaphysics.ts"
+    },
     "artsy/reaction": {
       "pull_request": "danger/pr.ts"
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "lib": ["es2017"],
-    "strict": true
+    "strict": true,
+    "noImplicitAny": false,
+    "strictNullChecks": false
   }
 }

--- a/upstream/metaphysics.ts
+++ b/upstream/metaphysics.ts
@@ -1,0 +1,23 @@
+import { danger, warn } from "danger"
+
+export default async () => {
+  const exchangeSchema = "src/data/exchange.graphql"
+  const exchange = {
+    owner: "artsy",
+    repo: "exchange",
+  }
+
+  if (danger.git.modified_files.includes(exchangeSchema)) {
+    const release = await danger.github.api.repos.getTags(exchange)
+    const production = release.data.find(r => r.name === "production")
+    const head = await danger.github.api.repos.getBranch({ ...exchange, branch: "master" })
+
+    if (!production) {
+      return fail("Exchange has no 'production' tag. Failing the PR until it can be found.")
+    }
+
+    if (head.data.commit.sha !== production.commit.sha) {
+      warn("This PR introduces changes to Exchange which are not yet available in production.")
+    }
+  }
+}

--- a/upstream/metaphysics.ts
+++ b/upstream/metaphysics.ts
@@ -1,7 +1,37 @@
 import { danger, warn } from "danger"
-import AWS from "aws-sdk"
+import { ECR } from "aws-sdk"
+
+const resolveSHA1ForTag = (ecr: ECR, tag: string) => {
+  return new Promise((resolve, reject) => {
+    const re = new RegExp("^[0-9a-f]{40}$")
+    ecr.describeImages({repositoryName: 'metaphysics',
+                        imageIds: [{imageTag: tag}]},
+    (err, data) => {
+        if (err) {
+            reject(err)
+        } else {
+          if (data.imageDetails.length != 1) {
+            reject(new Error(`Found multiple images matching tag "${tag}"`))
+          }
+          data.imageDetails[0].imageTags.forEach((imageTag) => {
+              if (re.test(imageTag)) {
+                  resolve(imageTag)
+              }
+          })
+          reject(new Error(`Cound not find a Git-SHA1 tag for image "${data.imageDetails[0].imageDigest}"`))
+        }
+    })
+  })
+}
 
 export default async () => {
-  const ecr = new AWS.ECR()
-  // Grab tags, compare them
+  const ecr = new ECR()
+  let productionSHA1
+  try {
+    productionSHA1 = await resolveSHA1ForTag(ecr, 'production')
+    return await danger.github.utils.fileContents("_schema.graphql", `artsy/metaphysics`, productionSHA1)
+  } catch(err) {
+    console.log(err)
+    return null
+  }
 }

--- a/upstream/metaphysics.ts
+++ b/upstream/metaphysics.ts
@@ -1,23 +1,7 @@
 import { danger, warn } from "danger"
+import AWS from "aws-sdk"
 
 export default async () => {
-  const exchangeSchema = "src/data/exchange.graphql"
-  const exchange = {
-    owner: "artsy",
-    repo: "exchange",
-  }
-
-  if (danger.git.modified_files.includes(exchangeSchema)) {
-    const release = await danger.github.api.repos.getTags(exchange)
-    const production = release.data.find(r => r.name === "production")
-    const head = await danger.github.api.repos.getBranch({ ...exchange, branch: "master" })
-
-    if (!production) {
-      return fail("Exchange has no 'production' tag. Failing the PR until it can be found.")
-    }
-
-    if (head.data.commit.sha !== production.commit.sha) {
-      warn("This PR introduces changes to Exchange which are not yet available in production.")
-    }
-  }
+  const ecr = new AWS.ECR()
+  // Grab tags, compare them
 }

--- a/upstream/metaphysics.ts
+++ b/upstream/metaphysics.ts
@@ -1,4 +1,3 @@
-import { danger, warn } from "danger"
 import { ECR } from "aws-sdk"
 
 const ecr = new ECR()

--- a/upstream/metaphysics.ts
+++ b/upstream/metaphysics.ts
@@ -1,7 +1,9 @@
 import { danger, warn } from "danger"
 import { ECR } from "aws-sdk"
 
-const resolveSHA1ForTag = (ecr: ECR, tag: string) => {
+const ecr = new ECR()
+
+const resolveSHA1ForTag = (tag: string) => {
   return new Promise((resolve, reject) => {
     const re = new RegExp("^[0-9a-f]{40}$")
     ecr.describeImages({repositoryName: 'metaphysics',
@@ -24,14 +26,10 @@ const resolveSHA1ForTag = (ecr: ECR, tag: string) => {
   })
 }
 
-export default async () => {
-  const ecr = new ECR()
-  let productionSHA1
-  try {
-    productionSHA1 = await resolveSHA1ForTag(ecr, 'production')
-    return await danger.github.utils.fileContents("_schema.graphql", `artsy/metaphysics`, productionSHA1)
-  } catch(err) {
-    console.log(err)
-    return null
-  }
+export const productionSHA1 = async () => {
+  return await resolveSHA1ForTag('production')
+}
+
+export const stagingSHA1 = async () => {
+  return await resolveSHA1ForTag('staging')
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,6 +462,21 @@ atob@^2.0.0:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.0.tgz#ab2b150e51d7b122b9efc8d7340c06b6c41076bc"
   integrity sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==
 
+aws-sdk@^2.382.0:
+  version "2.382.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.382.0.tgz#9212bc7aced9c051973578d06ea1978a57ccbd5f"
+  integrity sha512-wGjZLYo2ZxGTlj2cHy/0zOfYJKUVBQYG1vpW4Cnbgo3HTtOu906a6tqkiD8QuN0EyEkn7i+wyjSiUFOCh3T/2g==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.1.0"
+    xml2js "0.4.19"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -683,6 +698,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
+base64-js@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
+  integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -812,6 +832,15 @@ buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
+    isarray "^1.0.0"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -1661,6 +1690,11 @@ eventemitter3@^3.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
   integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 exec-sh@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
@@ -2428,6 +2462,16 @@ iconv-lite@~0.4.13:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
   integrity sha1-T9qjs4rLwsAxsEXQ7c3+HsqxjI0=
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
+ieee754@^1.1.4:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
+  integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
+
 import-local@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
@@ -2779,7 +2823,7 @@ isarray@0.0.1:
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
   integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -3206,6 +3250,11 @@ jira-client@^6.4.1:
   dependencies:
     babel-runtime "^6.20.0"
     request-promise "^4.1.1"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -4554,6 +4603,11 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
+punycode@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -4573,6 +4627,11 @@ qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
+
+querystring@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
+  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -4914,7 +4973,12 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-sax@^1.1.4, sax@^1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.1.4, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -5609,6 +5673,14 @@ url-template@^2.0.8:
   resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
   integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 use@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.0.tgz#14716bf03fdfefd03040aef58d8b4b85f3a7c544"
@@ -5629,7 +5701,7 @@ util.promisify@^1.0.0:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
 
-uuid@^3.0.0:
+uuid@3.1.0, uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
   integrity sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==
@@ -5828,6 +5900,19 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"


### PR DESCRIPTION
Re: https://github.com/artsy/README/issues/109

This is now unblocked because the AWS SDK is now available to Peril 
https://github.com/danger/peril/commit/a46c62e2f0329d9ffa34eb6ca8e2d334f6d9d654, and I can use that to grab the images to compare them.