### PR TITLE
Automates reminders to on-call engineers that they are running standup

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@types/graphql": "^14.0.3",
+    "googleapis": "^36.0.0",
     "graphql-schema-utils": "^0.6.5",
     "graphql-tools": "^4.0.3",
     "node-fetch": "^2.2.0"

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -36,7 +36,7 @@
     }
   },
   "tasks": {
-    "monday-informationals": ["tasks/weeklyRFCSummary.ts", "tasks/compareSchemas.ts"],
+    "monday-informationals": ["tasks/weeklyRFCSummary.ts", "tasks/compareSchemas.ts", "tasks/standupReminder.ts"],
     "slack-dev-channel": "tasks/slackDevChannel.ts",
     "daily-license-check": "tasks/dailyLicenseCheck.ts"
   },

--- a/tasks/standupReminder.ts
+++ b/tasks/standupReminder.ts
@@ -19,7 +19,7 @@ const run = async () => {
   try {
     await jwtClient.authorize()
     const events = await listEvents(jwtClient)
-    const today = new Date("2018-12-10") // TODO: Remove this testing date.
+    const today = new Date("2019-01-07") // TODO: Remove this testing date.
     const currentSupportEvents = events.filter(event => {
       const eventStart = new Date((event.start && event.start.date) || "")
       const eventEnd = new Date((event.end && event.end.date) || "")
@@ -32,11 +32,10 @@ const run = async () => {
       const end = event.end.dateTime || event.end.date
       console.log(`${start} - ${end}, ${event.summary}`)
     })
-    console.log(currentSupportEvents[0])
-    const onCallStaffEmails = currentSupportEvents.map(event => {
-      const attendee = event.attendees && event.attendees.length && event.attendees[0]
-      return attendee && attendee.email
-    })
+    // console.log(currentSupportEvents.length)
+    const onCallStaffEmails = currentSupportEvents
+      .reduce((acc, event) => acc.concat(event.attendees || []), [] as calendar_v3.Schema$EventAttendee[])
+      .map(attendee => attendee.email)
     console.log(onCallStaffEmails)
   } catch (error) {
     console.error(`Couldn't authorize: ${error}`)

--- a/tasks/standupReminder.ts
+++ b/tasks/standupReminder.ts
@@ -1,0 +1,64 @@
+import { danger } from "danger"
+import { google, calendar_v3 } from "googleapis"
+import { JWT } from "google-auth-library"
+
+// TODO: Move this into an env var.
+let privatekey: any = require("../private_key.json")
+
+const SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
+const CALENDAR_ID = "" // TODO: Reference fron env var.
+
+const run = async () => {
+  /*
+  Plan:
+  1. Look up Google Calendar somehow. [Done]
+  2. Somehow match the email addresses to Slack user IDs and construct a reminder message.
+  3. Post that message to #dev.
+  */
+  let jwtClient = new google.auth.JWT(privatekey.client_email, undefined, privatekey.private_key, SCOPES)
+  try {
+    await jwtClient.authorize()
+    const events = await listEvents(jwtClient)
+    const today = new Date("2018-12-10") // TODO: Remove this testing date.
+    const currentSupportEvents = events.filter(event => {
+      const eventStart = new Date((event.start && event.start.date) || "")
+      const eventEnd = new Date((event.end && event.end.date) || "")
+      const ongoingEvent = eventStart <= today
+      const extendsPastToday = eventEnd > new Date(today.getTime() + 3600 * 24 * 1000)
+      return ongoingEvent && extendsPastToday
+    })
+    currentSupportEvents.map((event: any, i: number) => {
+      const start = event.start.dateTime || event.start.date
+      const end = event.end.dateTime || event.end.date
+      console.log(`${start} - ${end}, ${event.summary}`)
+    })
+    console.log(currentSupportEvents[0])
+    const onCallStaffEmails = currentSupportEvents.map(event => {
+      const attendee = event.attendees && event.attendees.length && event.attendees[0]
+      return attendee && attendee.email
+    })
+    console.log(onCallStaffEmails)
+  } catch (error) {
+    console.error(`Couldn't authorize: ${error}`)
+  }
+}
+export default run
+
+// run()
+
+const listEvents = async (auth: JWT): Promise<calendar_v3.Schema$Event[]> => {
+  const cal = google.calendar({ version: "v3", auth })
+  try {
+    const response = await cal.events.list({
+      calendarId: CALENDAR_ID,
+      timeMin: new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString(), // Look a week ago.
+      maxResults: 10,
+      singleEvents: true,
+      orderBy: "startTime",
+    })
+    return response.data.items || []
+  } catch (error) {
+    console.error("The API returned an error: " + error)
+    return []
+  }
+}

--- a/tests/standupReminder.test.ts
+++ b/tests/standupReminder.test.ts
@@ -1,0 +1,82 @@
+import { calendar_v3 } from "googleapis"
+
+const mockSlackDevChannel = jest.fn()
+jest.mock("../tasks/slackDevChannel", () => ({
+  slackMessage: mockSlackDevChannel,
+}))
+const mockLookupByEmail = jest.fn()
+jest.mock("@slack/client", () => ({
+  WebClient: jest.fn().mockImplementation(() => ({
+    users: {
+      lookupByEmail: mockLookupByEmail,
+    },
+  })),
+}))
+
+import { sendMessageForEvents } from "../tasks/standupReminder"
+
+const today = "2019-01-07"
+const events = [
+  {
+    // One event that starts today.
+    start: { date: today },
+    end: { date: "2019-01-14" },
+    attendees: [{ email: "ash@example.com" }],
+  },
+  {
+    // One event that spans today.
+    start: { date: "2019-01-02" },
+    end: { date: "2019-01-09" },
+    attendees: [{ email: "orta@example.com" }],
+  },
+  {
+    // And one event that ends today.
+    start: { date: "2018-12-31" },
+    end: { date: today },
+    attendees: [{ email: "eloy@example.com" }],
+  },
+] as calendar_v3.Schema$Event[]
+
+describe("Monday standup reminders", () => {
+  beforeEach(() => {
+    console.log = jest.fn()
+  })
+
+  it("sends a message", async () => {
+    await sendMessageForEvents([])
+    expect(mockSlackDevChannel).toHaveBeenCalled()
+  })
+
+  describe("with mocked email lookup", () => {
+    beforeEach(() => {
+      mockLookupByEmail.mockImplementation(async obj => {
+        if (obj.email.startsWith("ash@")) {
+          return { ok: true, user: { id: "ASHID" } }
+        } else if (obj.email.startsWith("orta@")) {
+          return { ok: true, user: { id: "ORTAID" } }
+        } else {
+          return { ok: false }
+        }
+      })
+    })
+
+    it("looks up attendees on slack and mentions them", async () => {
+      var receivedMessage
+      mockSlackDevChannel.mockImplementation(message => (receivedMessage = message))
+      await sendMessageForEvents(events, new Date(today))
+      expect(receivedMessage).toEqual(
+        "<@ASHID>, <@ORTAID> it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md"
+      )
+    })
+
+    it("skips failed email lookups", async () => {
+      events[1].attendees = [{ email: "unknown@user.com" }]
+      var receivedMessage
+      mockSlackDevChannel.mockImplementation(message => (receivedMessage = message))
+      await sendMessageForEvents(events, new Date(today))
+      expect(receivedMessage).toEqual(
+        "<@ASHID> it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md"
+      )
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1770,6 +1770,11 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
   integrity sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
 
+extend@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+
 external-editor@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
@@ -2038,6 +2043,15 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
+gcp-metadata@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-0.7.0.tgz#6c35dbb52bda32a427bb9c98f54237ddd1b5406f"
+  integrity sha512-ffjC09amcDWjh3VZdkDngIo7WoluyC5Ag9PAYxZbmQLOLNI8lvPtoKTSCyU54j2gwy5roZh6sSMTfkY2ct7K3g==
+  dependencies:
+    axios "^0.18.0"
+    extend "^3.0.1"
+    retry-axios "0.3.2"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -2137,6 +2151,48 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+google-auth-library@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-2.0.1.tgz#32c6215e771538ef826cb65391a984a2c62ba57c"
+  integrity sha512-CWLKZxqYw4SE+fE3GWbVT9r/10h75w8lB3cdmmLpLtCfccFDcsI84qI5rx7npemlrHtKJh3C2HUz4s6SihCeIQ==
+  dependencies:
+    axios "^0.18.0"
+    gcp-metadata "^0.7.0"
+    gtoken "^2.3.0"
+    https-proxy-agent "^2.2.1"
+    jws "^3.1.5"
+    lodash.isstring "^4.0.1"
+    lru-cache "^4.1.3"
+    semver "^5.5.0"
+
+google-p12-pem@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-1.0.3.tgz#3d8acc140573339a5bca7b2f6a4b206bbea6d8d7"
+  integrity sha512-KGnAiMMWaJp4j4tYVvAjfP3wCKZRLv9M1Nir2wRRNWUYO7j1aX8O9Qgz+a8/EQ5rAvuo4SIu79n6SIdkNl7Msg==
+  dependencies:
+    node-forge "^0.7.5"
+    pify "^4.0.0"
+
+googleapis-common@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/googleapis-common/-/googleapis-common-0.4.0.tgz#3b3c2c26f731dcf72101239e70dfa3d677e079e6"
+  integrity sha512-G8U5eUhmCzvZa80BtfcL2ECPiIJxmJYsPPIY3/9iODrIvDkY75wtxnEobG7HDUprtn/3Es6mP6KevqNZ5u6t4g==
+  dependencies:
+    axios "^0.18.0"
+    google-auth-library "^2.0.0"
+    pify "^4.0.0"
+    qs "^6.5.2"
+    url-template "^2.0.8"
+    uuid "^3.2.1"
+
+googleapis@^36.0.0:
+  version "36.0.0"
+  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-36.0.0.tgz#9ba4c8b9a5f1b606f6271fabe65edde7d85b65d1"
+  integrity sha512-+0lkijBkCByKa0vrAEx1ez0agbdOMUMCwdXkXv0VpW2ImoKwUonWTowrAuF5WD1+nox6VIzmz/Vg86l+PvK+qg==
+  dependencies:
+    google-auth-library "^2.0.0"
+    googleapis-common "^0.4.0"
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -2169,6 +2225,17 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
+gtoken@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-2.3.0.tgz#4e0ffc16432d7041a1b3dbc1d97aac17a5dc964a"
+  integrity sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==
+  dependencies:
+    axios "^0.18.0"
+    google-p12-pem "^1.0.0"
+    jws "^3.1.4"
+    mime "^2.2.0"
+    pify "^3.0.0"
 
 handlebars@^4.0.3:
   version "4.0.10"
@@ -3398,7 +3465,7 @@ jwa@^1.1.5:
     ecdsa-sig-formatter "1.0.10"
     safe-buffer "^5.0.1"
 
-jws@^3.1.4:
+jws@^3.1.4, jws@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.1.5.tgz#80d12d05b293d1e841e7cb8b4e69e561adcf834f"
   integrity sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==
@@ -3752,6 +3819,14 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^4.1.3:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 macos-release@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
@@ -3887,6 +3962,11 @@ mime-types@~2.1.17:
   dependencies:
     mime-db "~1.30.0"
 
+mime@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
+  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
+
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
@@ -3994,6 +4074,11 @@ node-fetch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
   integrity sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA==
+
+node-forge@^0.7.5:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
+  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -4467,6 +4552,11 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pify@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -4563,6 +4653,11 @@ punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
   integrity sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=
+
+qs@^6.5.2:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
+  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
 
 qs@~6.4.0:
   version "6.4.0"
@@ -4843,6 +4938,11 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
+retry-axios@0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/retry-axios/-/retry-axios-0.3.2.tgz#5757c80f585b4cc4c4986aa2ffd47a60c6d35e13"
+  integrity sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ==
 
 retry@^0.12.0:
   version "0.12.0"
@@ -5638,6 +5738,11 @@ uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
   integrity sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
+
+uuid@^3.2.1:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
This PR automates a task I've been doing manually for most of the year, which is reminding the on-call engineers that it's their responsibility to run standup. 

Still left to do:

- [x] Put GSuite credentials and calendar ID into Peril's env var settings
- [x] Look up Slack users based on email addresses
- [x] Post message to Slack
- [x] Update Peril config to schedule task
- [x] Unit tests