### PR TITLE
Make addPatchLabel global

### DIFF
--- a/org/addPatchLabel.ts
+++ b/org/addPatchLabel.ts
@@ -3,7 +3,7 @@ import { danger } from "danger"
 export const labels = {
   Patch: {
     color: "E0E4CC",
-    description: "A deploy for bug fixes",
+    description: "A deploy for bug fixes or minor changes",
   },
   Minor: {
     color: "A7DBD8",
@@ -24,6 +24,12 @@ export const labels = {
 //
 export default async () => {
   const pr = danger.github.pr
+
+  const hasAutoRC = await danger.github.utils.fileContents(".autorc")
+  if (!hasAutoRC) {
+    console.log(`This repo not have an .autorc, so we're not adding a patch label .`)
+    return
+  }
 
   const patchLabelName = "Version: Patch"
   const requiredPrefix = "Version: "

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -10,6 +10,7 @@
     // Jira integration
     "pull_request": ["org/allPRs.ts", "org/jira/pr.ts"],
     "pull_request.closed": ["org/closedPRs.ts", "org/jira/pr.ts"],
+    "pull_request.opened": "org/addPatchLabel.ts",
     // The RFC process
     "issues": "org/rfc/addRFCToNewIssues.ts",
     "issues.labeled": "org/rfc/scheduleRFCsForLabels.ts",
@@ -20,8 +21,7 @@
   },
   "repos": {
     "artsy/reaction": {
-      "pull_request": "danger/pr.ts",
-      "pull_request.opened": "artsy/peril-settings@repos/reaction/addPatchLabel.ts"
+      "pull_request": "danger/pr.ts"
     },
     "artsy/force": {
       "pull_request": "dangerfile.ts"

--- a/tests/rfc_reaction_1095.test.ts
+++ b/tests/rfc_reaction_1095.test.ts
@@ -1,6 +1,9 @@
 jest.mock("danger", () => ({
   danger: {
     github: {
+      utils: {
+        fileContents: jest.fn(),
+      },
       pr: {
         number: 12,
         base: {
@@ -31,17 +34,28 @@ import { danger } from "danger"
 const mockGetLabels: jest.Mock = danger.github.api.issues.getLabels as any
 const mockCreateLabel: jest.Mock = danger.github.api.issues.createLabel as any
 const mockAddLabels: jest.Mock = danger.github.api.issues.addLabels as any
+const mockfileContents: jest.Mock = danger.github.utils.fileContents as any
 
-import addPatchLabel, { labels } from "../repos/reaction/addPatchLabel"
+import addPatchLabel, { labels } from "../org/addPatchLabel"
 
 afterEach(() => {
   mockGetLabels.mockReset()
   mockCreateLabel.mockReset()
   mockAddLabels.mockReset()
+  mockfileContents.mockReset()
+})
+
+it("Does nothing if there is no autorc", async () => {
+  mockfileContents.mockResolvedValueOnce("")
+
+  await addPatchLabel()
+
+  expect(danger.github.api.issues.getLabels).not.toBeCalled()
 })
 
 it("Does nothing if there's already a release label", async () => {
   danger.github.issue.labels = [{ name: "Version: Major" } as any]
+  mockfileContents.mockResolvedValueOnce("{}")
 
   await addPatchLabel()
 
@@ -53,6 +67,7 @@ it("Creates labels for this repo if there are no labels yet", async () => {
   danger.github.issue.labels = []
   // nothing set up in the repo yet
   mockGetLabels.mockResolvedValueOnce({ data: [] })
+  mockfileContents.mockResolvedValueOnce("{}")
 
   await addPatchLabel()
 
@@ -67,6 +82,7 @@ it("Posts a patch label if there are no labels already added", async () => {
   danger.github.issue.labels = []
   // the repo already has labels set up
   mockGetLabels.mockResolvedValueOnce({ data: [{ name: "Version: Patch" } as any] })
+  mockfileContents.mockResolvedValueOnce("{}")
 
   await addPatchLabel()
 


### PR DESCRIPTION
Related https://github.com/artsy/reaction/pull/1779

Moves `addPatchLabel` into the global namespace so that repos containing an `.autorc` can be evaluated.  