### PR TITLE
Makes sure that the folks who can't assign someone aren't asked

### DIFF
--- a/tests/rfc_13.test.ts
+++ b/tests/rfc_13.test.ts
@@ -9,22 +9,38 @@ beforeEach(() => {
   dm.warn = jest.fn()
 })
 
-it("warns when there's there's no assignee and no WIP in the title", () => {
-  dm.danger.github = { pr: { title: "My Thing", assignee: null } }
-  rfc13()
+it("warns when there's  no assignee and no WIP in the title", async () => {
+  // When the check membership API call does not raise
+  const api = { orgs: { checkMembership: () => {} } }
+  dm.danger.github = { pr: { title: "My Thing", assignee: null, user: { login: "someone" } }, api }
+  await rfc13()
   expect(dm.warn).toHaveBeenCalledWith(
     "Please assign someone to merge this PR, and optionally include people who should review."
   )
 })
 
-it("does not warn when there's there's no assignee and WIP in the title", () => {
-  dm.danger.github = { pr: { title: "[WIP] My thing", assignee: null } }
-  rfc13()
+it("does not warns when someone does nto have access to the org", async () => {
+  // When the check membership API call does not raise
+  const api = {
+    orgs: {
+      checkMembership: () => {
+        throw new Error()
+      },
+    },
+  }
+  dm.danger.github = { pr: { title: "My Thing", assignee: null, user: { login: "someone" } }, api }
+  await rfc13()
   expect(dm.warn).not.toBeCalled()
 })
 
-it("does not warn when there's there's an assignee", () => {
+it("does not warn when there's there's no assignee and WIP in the title", async () => {
+  dm.danger.github = { pr: { title: "[WIP] My thing", assignee: null } }
+  await rfc13()
+  expect(dm.warn).not.toBeCalled()
+})
+
+it("does not warn when there's there's an assignee", async () => {
   dm.danger.github = { pr: { title: "My thing", assignee: {} } }
-  rfc13()
+  await rfc13()
   expect(dm.warn).not.toBeCalled()
 })


### PR DESCRIPTION
We get the occasional PR, we shouldn't be asking these folks to assign someone when they can't do it.