### PR TITLE
Forbids PRs from forks on mobile repos

### DIFF
--- a/org/mobilePRsForbidForks.ts
+++ b/org/mobilePRsForbidForks.ts
@@ -1,0 +1,27 @@
+import { danger, warn, fail } from "danger"
+
+// Mobile repos at Artsy have historically used PRs from branches on the repo,
+// instead of PRs from forks. Our tooling still relies on this; PRs from forks
+// won't even trigger CI builds on some of these projects, so we need to warn
+// the authors via Peril.
+const mobileRepos = ["eigen", "emission", "eidolon", "energy", "emergence"]
+
+export default async () => {
+  const pr = danger.github.pr
+  const isMobileRepo = mobileRepos.filter(name => pr.base.repo.name.endsWith(name)).length > 0
+
+  if (isMobileRepo && pr.head.repo.fork) {
+    try {
+      // Are they a member of the Artsy GitHub org? This will throw if not.
+      await danger.github.api.orgs.checkMembership({ org: "artsy", username: pr.user.login })
+      fail(
+        "Artsy staff submitting PRs on this repo need to submit them from branches on the repo, and not from forks of the repo. This is a limitation of our CI infrastructure; please close this PR and re-open it from a branch."
+      )
+    } catch (error) {
+      // They are not.
+      warn(
+        "This PR is on a repo with limited CI support for open source contributors; the reviewers may need to check out your code locally to run the tests."
+      )
+    }
+  }
+}

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -8,7 +8,7 @@
     // Keep a list of all deployments in slack
     "create (ref_type == tag)": "org/newRelease.ts",
     // Jira integration
-    "pull_request": ["org/allPRs.ts", "org/jira/pr.ts"],
+    "pull_request": ["org/allPRs.ts", "org/jira/pr.ts", "org/mobilePRsForbidForks.ts"],
     "pull_request.closed": ["org/closedPRs.ts", "org/jira/pr.ts"],
     "pull_request.opened": "org/addPatchLabel.ts",
     // The RFC process

--- a/tests/mobilePRsForbidForks.test.ts
+++ b/tests/mobilePRsForbidForks.test.ts
@@ -36,21 +36,24 @@ describe("mobilePRsForbidForks", () => {
     })
 
     it("fails builds for Artsy staff on forks", async () => {
-      ;(dm.danger.github.api.orgs.checkMembership as jest.Mock).mockImplementation(() => Promise.resolve())
+      const mockCheckMembership: jest.Mock = dm.danger.github.api.orgs.checkMembership as any
+      mockCheckMembership.mockImplementation(() => Promise.resolve())
       dm.danger.github.pr.head.repo.fork = true
       await mobilePRsForbidForks()
       expect(dm.fail).toHaveBeenCalled()
     })
 
     it("warns builds for OSS contributors on forks", async () => {
-      ;(dm.danger.github.api.orgs.checkMembership as jest.Mock).mockRejectedValueOnce("some error")
+      const mockCheckMembership: jest.Mock = dm.danger.github.api.orgs.checkMembership as any
+      mockCheckMembership.mockRejectedValueOnce("some error")
       dm.danger.github.pr.head.repo.fork = true
       await mobilePRsForbidForks()
       expect(dm.warn).toHaveBeenCalled()
     })
 
     it("does nothing when submitted from a branch", async () => {
-      ;(dm.danger.github.api.orgs.checkMembership as jest.Mock).mockImplementation(() => Promise.resolve())
+      const mockCheckMembership: jest.Mock = dm.danger.github.api.orgs.checkMembership as any
+      mockCheckMembership.mockImplementation(() => Promise.resolve())
       await mobilePRsForbidForks()
       expect(dm.fail).not.toHaveBeenCalled()
     })

--- a/tests/mobilePRsForbidForks.test.ts
+++ b/tests/mobilePRsForbidForks.test.ts
@@ -1,0 +1,70 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import mobilePRsForbidForks from "../org/mobilePRsForbidForks"
+
+describe("mobilePRsForbidForks", () => {
+  beforeEach(() => {
+    dm.danger = {
+      github: {
+        api: {
+          orgs: {
+            checkMembership: jest.fn(),
+          },
+        },
+        pr: {
+          user: {
+            login: "some_user",
+          },
+          head: {
+            repo: {},
+          },
+          base: {
+            repo: {},
+          },
+        },
+      },
+    }
+    dm.warn = jest.fn()
+    dm.fail = jest.fn()
+  })
+
+  describe("on mobile repos", () => {
+    beforeEach(() => {
+      dm.danger.github.pr.base.repo.name = "eigen"
+    })
+
+    it("fails builds for Artsy staff on forks", async () => {
+      ;(dm.danger.github.api.orgs.checkMembership as jest.Mock).mockImplementation(() => Promise.resolve())
+      dm.danger.github.pr.head.repo.fork = true
+      await mobilePRsForbidForks()
+      expect(dm.fail).toHaveBeenCalled()
+    })
+
+    it("warns builds for OSS contributors on forks", async () => {
+      ;(dm.danger.github.api.orgs.checkMembership as jest.Mock).mockRejectedValueOnce("some error")
+      dm.danger.github.pr.head.repo.fork = true
+      await mobilePRsForbidForks()
+      expect(dm.warn).toHaveBeenCalled()
+    })
+
+    it("does nothing when submitted from a branch", async () => {
+      ;(dm.danger.github.api.orgs.checkMembership as jest.Mock).mockImplementation(() => Promise.resolve())
+      await mobilePRsForbidForks()
+      expect(dm.fail).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("on non-mobile repos", () => {
+    beforeEach(() => {
+      dm.danger.github.pr.base.repo.name = "force"
+    })
+
+    it("does nothing", async () => {
+      await mobilePRsForbidForks()
+      expect(dm.fail).not.toHaveBeenCalled()
+      expect(dm.warn).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
We had a [PR](https://github.com/artsy/eigen/pull/2757) this week that got merged into Eigen despite failing unit tests because Eigen doesn't build PRs on forks. This is a historical quirk; the "mobile team" has always used branches and the rest of Artsy uses forks. Rather than rebuild a half decade of mobile repo tooling, this PR adds a Peril rule that will fail builds from Artsy staff who submit PRs from forks on mobile repos (and it will warn on PRs from OSS contributors).