### PR TITLE
Change mog commit to be title of PR

### DIFF
--- a/org/mergeOnGreen.ts
+++ b/org/mergeOnGreen.ts
@@ -35,8 +35,11 @@ export const rfc10 = async (status: Status) => {
       return console.log("PR does not have Merge on Green")
     }
 
+    // Strip any "@user =>" prefixes from the pr title
+    const prTitle = issue.data.title.replace(/@(\w|-)+\s+=>\s+/, "")
+
     // Merge the PR
-    await api.pullRequests.merge({ owner, repo, number, commit_title: `Merge pull request #${number} by Peril` })
+    await api.pullRequests.merge({ owner, repo, number, commit_title: `${prTitle} (#${number})` })
     console.log(`Merged Pull Request ${number}`)
   }
 }

--- a/org/mergeOnGreen.ts
+++ b/org/mergeOnGreen.ts
@@ -35,11 +35,16 @@ export const rfc10 = async (status: Status) => {
       return console.log("PR does not have Merge on Green")
     }
 
-    // Strip any "@user =>" prefixes from the pr title
-    const prTitle = issue.data.title.replace(/@(\w|-)+\s+=>\s+/, "")
+    let commitTitle = `Merge pull request #${number} by Peril`
+
+    if (issue.data.title) {
+      // Strip any "@user =>" prefixes from the pr title
+      const prTitle = issue.data.title.replace(/@(\w|-)+\s+=>\s+/, "")
+      commitTitle = `${prTitle} (#${number})`
+    }
 
     // Merge the PR
-    await api.pullRequests.merge({ owner, repo, number, commit_title: `${prTitle} (#${number})` })
+    await api.pullRequests.merge({ owner, repo, number, commit_title: commitTitle })
     console.log(`Merged Pull Request ${number}`)
   }
 }


### PR DESCRIPTION
This updates the merge on green commit message to be the PR title with the PR number in parenthesis. This update will make the changelogs generated by `auto` have more useful entries. This is the same format that is used if you do a squash merge in github. 

Also, a minor thing. This removes any `@user => ` prefixes from PR titles. 