### PR TITLE
Notifies Jira tickets when related Eigen betas are deployed

### DIFF
--- a/org/newEigenBeta.ts
+++ b/org/newEigenBeta.ts
@@ -15,6 +15,10 @@ export default async (create: Create) => {
   if (create.ref_type !== "tag") {
     return console.log("Skipping because it's not a tag")
   }
+  if (create.ref.endsWith("-submission")) {
+    return console.log("Skipping because it's not a beta")
+  }
+
   const api = danger.github.api
 
   const tag = create.ref

--- a/org/newEigenBeta.ts
+++ b/org/newEigenBeta.ts
@@ -1,0 +1,117 @@
+import { peril } from "danger"
+import { Create } from "github-webhook-event-types"
+import { danger } from "danger"
+
+import * as semverSort from "semver-sort"
+import * as JiraApi from "jira-client"
+
+import * as IssueJSON from "../fixtures/jira_issue_example.json"
+type Issue = typeof IssueJSON
+
+const companyPrefix = "artsyproduct"
+
+// Implementation borrowed from https://github.com/danger/peril-settings/blob/b306662628f1a4c5c4ebc5f0531e15561fe60fa5/org/new_tag.ts#L12-L64
+export default async (create: Create) => {
+  if (create.ref_type !== "tag") {
+    return console.log("Skipping because it's not a tag")
+  }
+  const api = danger.github.api
+
+  const tag = create.ref
+  const thisRepo = { owner: create.repository.owner.login, repo: create.repository.name }
+
+  // Grab all tags, should be latest ~20
+  const allTagsResponse = await api.repos.getTags(thisRepo)
+  const allTags: Tag[] = allTagsResponse.data
+
+  // Sort the tags in semver, so we can know specifically what range to
+  // work out the commits
+  const semverStrings: string[] = semverSort.desc(allTags.map(tag => tag.name))
+  const versionIndex = semverStrings.findIndex(version => version === tag)
+  const releaseMinusOne = semverStrings[versionIndex + 1]
+
+  // Bail if we can't find a release
+  if (!releaseMinusOne) {
+    return console.log(`Couldn't locate release for ${tag} tag.`)
+  }
+  // Ask for the commits
+  const compareResults = await api.repos.compareCommits({ ...thisRepo, base: releaseMinusOne, head: tag })
+  compareResults.data
+  const compareData: CompareResults = compareResults.data
+
+  // Pull out all the GH crafted merge commits on a repo
+  const numberExtractor = /Merge pull request #(\d*)/
+  const commitMessages = compareData.commits.map(c => c.commit.message)
+  const prMerges = commitMessages.filter(message => message && message.startsWith("Merge pull request #"))
+
+  // This is now a number array of PR ids
+  // e.g. [ 930, 934, 937, 932, 938 ]
+  const prs = prMerges
+    .map(msg => msg.match(numberExtractor) && msg.match(numberExtractor)![1])
+    .filter(pr => pr)
+    .map((pr: any) => parseInt(pr))
+
+  const {
+    getJiraTicketIDsFromCommits,
+    getJiraTicketIDsFromText,
+    uniq,
+    makeJiraTransition,
+  } = await import("./jira/utils")
+
+  // We know we have something to work with now
+  const jira: JiraApi.default = new (JiraApi as any)({
+    protocol: "https",
+    host: `${companyPrefix}.atlassian.net`,
+    apiVersion: "2",
+    strictSSL: true,
+    username: process.env.JIRA_EMAIL,
+    password: process.env.JIRA_ACCESS_TOKEN,
+  })
+
+  for (const prID of prs) {
+    const prResponse = await api.pullRequests.get({ ...thisRepo, number: prID })
+    const prData = prResponse.data
+    const prBody = prData.body
+
+    // Grab tickets from the PR body, and the commit messages
+    const tickets = uniq([
+      ...getJiraTicketIDsFromText(prBody),
+      ...getJiraTicketIDsFromCommits(compareData.commits.map(c => c.commit)),
+    ])
+
+    // Bail if we have no work to do
+    if (!tickets.length) {
+      return console.log("No Jira ticket references found")
+    }
+
+    tickets.forEach(async ticketID => {
+      try {
+        const message = `Changes related to this issue have been released in the latest Eigen beta, ${tag}. You can download it in TestFlight; contact the #front-end-ios Slack channel for answers to any questions.`
+        console.log(`Leaving a comment on ${ticketID}`)
+        await jira.addComment(ticketID, message)
+      } catch (err) {
+        console.log(`Had an issue changing the status of ${ticketID}`)
+        console.log(err.message)
+        console.log(err)
+      }
+    })
+  }
+}
+
+interface Tag {
+  name: string
+  commit: {
+    sha: string
+    url: string
+  }
+}
+
+interface Commit {
+  commit: {
+    message: string
+  }
+}
+
+interface CompareResults {
+  commits: Commit[]
+}

--- a/org/newEigenBeta.ts
+++ b/org/newEigenBeta.ts
@@ -66,9 +66,12 @@ const ticketsFromCommits = async (commits: CompareResults, repo: Repo): Promise<
   // This is now a number array of PR ids
   // e.g. [ 930, 934, 937, 932, 938 ]
   const prs = prMerges
-    .map(msg => msg.match(numberExtractor) && msg.match(numberExtractor)![1])
-    .filter(pr => pr)
-    .map((pr: any) => parseInt(pr))
+    .map(message => {
+      const matches = message.match(numberExtractor) || []
+      const capture = matches[1]
+      return parseInt(capture)
+    })
+    .filter(Boolean)
 
   const prBodies = await Promise.all(
     prs.map(async pr => {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "googleapis": "^36.0.0",
     "graphql-schema-utils": "^0.6.5",
     "graphql-tools": "^4.0.3",
+    "lodash": "^4.17.10",
     "node-fetch": "^2.2.0",
     "semver": "^5.4.1",
     "semver-sort": "^0.0.4"
@@ -33,6 +34,7 @@
     "lint-staged": "^7.2.2",
     "prettier": "^1.15.2",
     "ts-jest": "^23.1.4",
+    "@types/lodash": "^4.14.116",
     "ts-node": "^7.0.1",
     "typescript": "^3.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "googleapis": "^36.0.0",
     "graphql-schema-utils": "^0.6.5",
     "graphql-tools": "^4.0.3",
-    "node-fetch": "^2.2.0"
+    "node-fetch": "^2.2.0",
+    "semver": "^5.4.1",
+    "semver-sort": "^0.0.4"
   },
   "devDependencies": {
     "@slack/client": "^4.8.0",

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -37,6 +37,9 @@
     },
     "artsy/peril-settings": {
       "pull_request": "dangerfile.ts"
+    },
+    "artsy/eigen": {
+      "create (ref_type == tag)": "org/newEigenBeta.ts"
     }
   },
   "tasks": {

--- a/tests/newEigenBeta.test.ts
+++ b/tests/newEigenBeta.test.ts
@@ -43,6 +43,11 @@ describe(subject, () => {
     expect(dm.danger.github.api.repos.getTags).not.toHaveBeenCalled()
   })
 
+  it("skips app store submissions", async () => {
+    await subject(({ ref_type: "tag", ref: "1.0.0-2019.01.30-submission" } as any) as Create)
+    expect(dm.danger.github.api.repos.getTags).not.toHaveBeenCalled()
+  })
+
   it("skips when there is no previous release", async () => {
     mockGetTags.mockResolvedValue({
       data: [

--- a/tests/newEigenBeta.test.ts
+++ b/tests/newEigenBeta.test.ts
@@ -1,0 +1,99 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+const mockJiraAddComment = jest.fn()
+jest.mock("jira-client", () =>
+  jest.fn().mockImplementation(() => ({
+    addComment: mockJiraAddComment,
+  }))
+)
+
+import subject from "../org/newEigenBeta"
+import { Create } from "github-webhook-event-types"
+
+let mockGetTags: jest.Mock
+let mockCompareCommits: jest.Mock
+let mockGetPullRequests: jest.Mock
+describe(subject, () => {
+  beforeEach(() => {
+    mockJiraAddComment.mockReset()
+    dm.danger = {
+      github: {
+        api: {
+          repos: {
+            getTags: jest.fn(),
+            compareCommits: jest.fn(),
+          },
+          pullRequests: {
+            get: jest.fn(),
+          },
+        },
+      },
+    }
+    mockGetTags = dm.danger.github.api.repos.getTags as any
+    mockCompareCommits = dm.danger.github.api.repos.compareCommits as any
+    mockGetPullRequests = dm.danger.github.api.pullRequests.get as any
+
+    console.log = jest.fn() // To silence test subject.
+  })
+
+  it("skips non-tag refs", async () => {
+    await subject(({ ref_type: "branch" } as any) as Create)
+    expect(dm.danger.github.api.repos.getTags).not.toHaveBeenCalled()
+  })
+
+  it("skips when there is no previous release", async () => {
+    mockGetTags.mockResolvedValue({
+      data: [
+        {
+          name: "1.1.0",
+        },
+      ],
+    })
+    await subject(mockCreate)
+    expect(dm.danger.github.api.repos.compareCommits).not.toHaveBeenCalled()
+  })
+
+  describe("with a previous release", () => {
+    beforeEach(() => {
+      mockGetTags.mockResolvedValue({
+        data: [{ name: "1.0.0" }, { name: "1.1.0" }],
+      })
+    })
+
+    it("comments based on ticket references in commit messages", async () => {
+      mockCompareCommits.mockResolvedValue({
+        data: {
+          commits: [{ commit: { message: "Fixes GROW-123 ticket." } }],
+        },
+      })
+      await subject(mockCreate)
+      expect(mockJiraAddComment).toHaveBeenCalledWith("GROW-123", expect.stringContaining("1.1.0"))
+    })
+
+    it("comments based on ticket references in PR body", async () => {
+      mockCompareCommits.mockResolvedValue({
+        data: {
+          commits: [{ commit: { message: "Merge pull request #1" } }],
+        },
+      })
+      mockGetPullRequests.mockResolvedValue({
+        data: {
+          body: "This is a ticket for GROW-123.",
+        },
+      })
+      await subject(mockCreate)
+      expect(mockJiraAddComment).toHaveBeenCalledWith("GROW-123", expect.stringContaining("1.1.0"))
+    })
+  })
+})
+
+const mockCreate = {
+  ref_type: "tag",
+  ref: "1.1.0",
+  repository: {
+    owner: { login: "artsy" },
+    name: "eigen",
+  },
+} as Create

--- a/tests/newEigenBeta.test.ts
+++ b/tests/newEigenBeta.test.ts
@@ -39,12 +39,12 @@ describe(subject, () => {
   })
 
   it("skips non-tag refs", async () => {
-    await subject(({ ref_type: "branch" } as any) as Create)
+    await subject(({ ...mockCreate, ref_type: "branch" } as any) as Create)
     expect(dm.danger.github.api.repos.getTags).not.toHaveBeenCalled()
   })
 
   it("skips app store submissions", async () => {
-    await subject(({ ref_type: "tag", ref: "1.0.0-2019.01.30-submission" } as any) as Create)
+    await subject(({ ...mockCreate, ref_type: "tag", ref: "1.0.0-2019.01.30-submission" } as any) as Create)
     expect(dm.danger.github.api.repos.getTags).not.toHaveBeenCalled()
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -112,6 +112,11 @@
     "@types/node" "*"
     "@types/request" "*"
 
+"@types/lodash@^4.14.116":
+  version "4.14.120"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.120.tgz#cf265d06f6c7a710db087ed07523ab8c1a24047b"
+  integrity sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw==
+
 "@types/loglevel@^1.5.3":
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/@types/loglevel/-/loglevel-1.5.3.tgz#adfce55383edc5998a2170ad581b3e23d6adb5b8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5024,12 +5024,25 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
+semver-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-1.0.0.tgz#92a4969065f9c70c694753d55248fc68f8f652c9"
+  integrity sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=
+
+semver-sort@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/semver-sort/-/semver-sort-0.0.4.tgz#34fdbddc6a6b2b4161398c3c4dba56243bfeaa8b"
+  integrity sha1-NP293GprK0FhOYw8TbpWJDv+qos=
+  dependencies:
+    semver "^5.0.3"
+    semver-regex "^1.0.0"
+
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
   integrity sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==
 
-semver@^5.0.1:
+semver@^5.0.1, semver@^5.0.3:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==


### PR DESCRIPTION
As discussed back in [December's Front-End iOS Practice meeting](https://www.notion.so/artsy/December-7-2018-Meeting-Notes-a1428a9d88924551883e9c9eebfdbc97), we want to automate a notification on Jira tickets when changes related to those tickets get deployed in an Eigen beta. There was interest in doing this for Force as well, but I wanted to keep the scope limited for the initial implementation.

This is a WIP because I need to write some unit tests. I wanted to get my changes up for some early feedback. I found the [existing implementation](https://github.com/danger/peril-settings/blob/b306662628f1a4c5c4ebc5f0531e15561fe60fa5/org/new_tag.ts#L12-L64) that @orta linked to very helpful.