### PR TITLE
Starts a new sup recurring task

### DIFF
--- a/org/jira/pr.ts
+++ b/org/jira/pr.ts
@@ -4,7 +4,7 @@ const companyPrefix = "artsyproduct"
 const wipLabels = ["in review", "in progress"]
 const mergedLabels = ["merged", "monitor/qa"]
 
-import { danger } from "danger"
+import { danger, peril } from "danger"
 import { PullRequest } from "github-webhook-event-types"
 import * as JiraApi from "jira-client"
 
@@ -36,8 +36,8 @@ export default async (webhook: PullRequest) => {
     host: `${companyPrefix}.atlassian.net`,
     apiVersion: "2",
     strictSSL: true,
-    username: process.env.JIRA_EMAIL,
-    password: process.env.JIRA_ACCESS_TOKEN,
+    username: peril.env.JIRA_EMAIL,
+    password: peril.env.JIRA_ACCESS_TOKEN,
   })
 
   console.log(`Looking at ${sentence(tickets)}.`)

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -48,10 +48,12 @@
     ],
     "slackup-reminder-tmp": "tasks/standupReminder.ts",
     "slack-dev-channel": "tasks/slackDevChannel.ts",
-    "daily-license-check": "tasks/dailyLicenseCheck.ts"
+    "daily-license-check": "tasks/dailyLicenseCheck.ts",
+    "simple-sups": ["tasks/supGP.js"]
   },
   "scheduler": {
     "daily": "daily-license-check",
-    "monday-morning-est": "monday-informationals"
+    "monday-morning-est": "monday-informationals",
+    "thursday-morning-est": "simple-sups"
   }
 }

--- a/tasks/standupReminder.ts
+++ b/tasks/standupReminder.ts
@@ -1,9 +1,10 @@
 import { google, calendar_v3 } from "googleapis"
 import { WebClient } from "@slack/client"
+import { peril } from "danger"
 
-let googleKey: any = JSON.parse(process.env.GOOGLE_APPS_PRIVATE_KEY_JSON || "{}")
+let googleKey: any = JSON.parse(peril.env.GOOGLE_APPS_PRIVATE_KEY_JSON || "{}")
 const SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
-const CALENDAR_ID = process.env.ON_CALL_CALENDAR_ID || ""
+const CALENDAR_ID = peril.env.ON_CALL_CALENDAR_ID || ""
 
 export default async () => {
   const events = await retrieveCalendarEvents()
@@ -43,7 +44,7 @@ export const sendMessageForEvents = async (events: calendar_v3.Schema$Event[], t
   )
   console.log(`The following emails are on call: ${onCallStaffEmails}. Now looking up Slack IDs.`)
 
-  const slackToken = process.env.SLACK_WEB_API_TOKEN
+  const slackToken = peril.env.SLACK_WEB_API_TOKEN
   const web = new WebClient(slackToken)
   const onCallStaffUsers = await Promise.all(onCallStaffEmails.map(email => web.users.lookupByEmail({ email })))
   const onCallStaffMentions = onCallStaffUsers

--- a/tasks/supGP.js
+++ b/tasks/supGP.js
@@ -1,0 +1,29 @@
+// @ts-check
+// Why JS? So that I can ensure that there is at least one Babelified file
+// in the Artsy peril settings.
+
+import fetch from "node-fetch"
+
+// https://team.artsy.net/api?query=%7B%0A%20%20members(team%3A%22Gallery%20Partnerships%22)%20%7B%0A%20%20%20%20name%0A%20%20%20%20slackID%0A%20%20%20%20country%0A%20%20%20%20city%0A%20%20%7D%0A%7D
+
+const query = `
+{
+  members(team:"Gallery Partnerships") {
+    name
+    slackID
+    country
+    city
+  }
+}
+`
+
+export default async () => {
+  const req = await fetch("https://team.artsy.net/api", {
+    method: "POST",
+    headers: { secret: peril.env.TEAM_NAV_SECRET },
+    body: { query },
+  })
+
+  const data = await req.json()
+  console.log(data)
+}

--- a/tests/standupReminder.test.ts
+++ b/tests/standupReminder.test.ts
@@ -1,9 +1,16 @@
 import { calendar_v3 } from "googleapis"
 
+jest.mock("danger", () => ({
+  peril: {
+    env: {},
+  },
+}))
+
 const mockSlackDevChannel = jest.fn()
 jest.mock("../tasks/slackDevChannel", () => ({
   slackMessage: mockSlackDevChannel,
 }))
+
 const mockLookupByEmail = jest.fn()
 jest.mock("@slack/client", () => ({
   WebClient: jest.fn().mockImplementation(() => ({


### PR DESCRIPTION
Some teams want a weekly mini-sup just for their team, this is the infra so I can iterate on that without making a million PRs. 

Also moves `process.env` code to `peril.env` because I'll be removing that feature in https://github.com/danger/peril/pull/417 because lambdas can be warm launched unlike in the past.