### PR TITLE
Update standup reminder to pull on-call participants from OpsGenie

### DIFF
--- a/tasks/standupReminder.ts
+++ b/tasks/standupReminder.ts
@@ -3,6 +3,7 @@ import { WebClient } from "@slack/client"
 import { peril } from "danger"
 import fetch from "node-fetch"
 import querystring from "querystring"
+import { concat, uniq } from "lodash"
 
 let googleKey: any = JSON.parse(peril.env.GOOGLE_APPS_PRIVATE_KEY_JSON || "{}")
 const SCOPES = ["https://www.googleapis.com/auth/calendar.readonly"]
@@ -12,11 +13,11 @@ export default async () => {
   // Backed by Google Calendar
   const events = await retrieveCalendarEvents()
   const calendarOnCallStaffEmails = emailsForCalendarEvents(events)
-  await sendMessageForEmails(calendarOnCallStaffEmails)
 
   // Backed by OpsGenie
   const opsGenieOnCallStaffEmails = await emailsFromOpsGenie()
-  await sendMessageForEmails(opsGenieOnCallStaffEmails)
+
+  await sendMessageForEmails(uniq(concat(calendarOnCallStaffEmails, opsGenieOnCallStaffEmails)))
 }
 
 const retrieveCalendarEvents = async (): Promise<calendar_v3.Schema$Event[]> => {

--- a/tasks/standupReminder.ts
+++ b/tasks/standupReminder.ts
@@ -42,7 +42,7 @@ const retrieveCalendarEvents = async (): Promise<calendar_v3.Schema$Event[]> => 
   }
 }
 
-const emailsForCalendarEvents = (events: calendar_v3.Schema$Event[], today = new Date()) => {
+export const emailsForCalendarEvents = (events: calendar_v3.Schema$Event[], today = new Date()) => {
   const currentSupportEvents = events.filter(event => {
     const eventStart = new Date((event.start && event.start.date) || "")
     const eventEnd = new Date((event.end && event.end.date) || "")
@@ -96,7 +96,7 @@ const emailsFromOpsGenie = async (today = new Date()) => {
   })
 }
 
-const sendMessageForEmails = async (emails: string[]) => {
+export const sendMessageForEmails = async (emails: string[]) => {
   console.log(`The following emails are on call: ${emails}. Now looking up Slack IDs.`)
 
   const slackToken = peril.env.SLACK_WEB_API_TOKEN
@@ -110,13 +110,11 @@ const sendMessageForEmails = async (emails: string[]) => {
 
   const { slackMessage } = await import("./slackDevChannel")
 
-  if (onCallStaffMentions.length > 0) {
-    await slackMessage(
-      `${onCallStaffMentions.join(
-        ", "
-      )} it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md`
-    )
-  }
+  await slackMessage(
+    `${onCallStaffMentions.join(
+      ", "
+    )} it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md`
+  )
 }
 
 function filterUndefineds<T>(t: T | undefined): t is T {

--- a/tasks/standupReminder.ts
+++ b/tasks/standupReminder.ts
@@ -2,7 +2,7 @@ import { google, calendar_v3 } from "googleapis"
 import { WebClient } from "@slack/client"
 import { peril } from "danger"
 import fetch from "node-fetch"
-import querystring from "querystring"
+import * as querystring from "querystring"
 import { concat, uniq } from "lodash"
 
 let googleKey: any = JSON.parse(peril.env.GOOGLE_APPS_PRIVATE_KEY_JSON || "{}")
@@ -78,7 +78,7 @@ export const emailsForCalendarEvents = (events: calendar_v3.Schema$Event[], toda
   return onCallStaffEmails
 }
 
-const emailsFromOpsGenie = async (today = new Date()) => {
+export const emailsFromOpsGenie = async (today = new Date()) => {
   const targetDate = new Date(today.getTime() + 3600 * 24 * 1000)
   const qs = querystring.stringify({ date: targetDate.toISOString() })
   const url = `https://api.opsgenie.com/v2/schedules/${peril.env.OPSGENIE_SCHEDULE_ID}/on-calls?${qs}`
@@ -92,7 +92,7 @@ const emailsFromOpsGenie = async (today = new Date()) => {
   })
 
   const body = await req.json()
-  return body.data.onCallParticipants.reduce((participant: any) => {
+  return body.data.onCallParticipants.map((participant: any) => {
     return participant.name
   })
 }

--- a/tests/standupReminder.test.ts
+++ b/tests/standupReminder.test.ts
@@ -20,7 +20,7 @@ jest.mock("@slack/client", () => ({
   })),
 }))
 
-import { sendMessageForEvents } from "../tasks/standupReminder"
+import { sendMessageForEmails, emailsForCalendarEvents } from "../tasks/standupReminder"
 
 const today = "2019-01-07"
 const events = [
@@ -50,7 +50,7 @@ describe("Monday standup reminders", () => {
   })
 
   it("sends a message", async () => {
-    await sendMessageForEvents([])
+    await sendMessageForEmails([])
     expect(mockSlackDevChannel).toHaveBeenCalled()
   })
 
@@ -70,7 +70,8 @@ describe("Monday standup reminders", () => {
     it("looks up attendees on slack and mentions them", async () => {
       var receivedMessage
       mockSlackDevChannel.mockImplementation(message => (receivedMessage = message))
-      await sendMessageForEvents(events, new Date(today))
+      const emails = emailsForCalendarEvents(events, new Date(today))
+      await sendMessageForEmails(emails)
       expect(receivedMessage).toEqual(
         "<@ASHID>, <@ORTAID> it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md"
       )
@@ -80,7 +81,9 @@ describe("Monday standup reminders", () => {
       events[1].attendees = [{ email: "unknown@user.com" }]
       var receivedMessage
       mockSlackDevChannel.mockImplementation(message => (receivedMessage = message))
-      await sendMessageForEvents(events, new Date(today))
+      const emails = emailsForCalendarEvents(events, new Date(today))
+
+      await sendMessageForEmails(emails)
       expect(receivedMessage).toEqual(
         "<@ASHID> it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md"
       )


### PR DESCRIPTION
We've started to trial OpsGenie to schedule on-call rotations. This commit updates our weekly standup reminder to use on-call participants from OpsGenie, if available. This should not overlap with our existing Google Calendar-backed scheduling.

This updates requires two new environment variables:
- `OPSGENIE_SCHEDULE_ID`
- `OPSGENIE_API_KEY`



RFC: https://github.com/artsy/README/issues/184