### PR TITLE
don't fail prs on no assignee if renovate

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -49,8 +49,9 @@ export const rfc7 = async () => {
 // https://github.com/artsy/peril-settings/issues/13
 export const rfc13 = async () => {
   const pr = danger.github.pr
+  const isRenovate = pr.user.login.toLowerCase().includes("renovate")
   const wipPR = pr.title.includes("WIP ") || pr.title.includes("[WIP]")
-  if (!wipPR && pr.assignee === null) {
+  if (!isRenovate && !wipPR && pr.assignee === null) {
     // Validate they are in the org, before asking to assign
     try {
       await danger.github.api.orgs.checkMembership({ org: "artsy", username: danger.github.pr.user.login })

--- a/tests/rfc_13.test.ts
+++ b/tests/rfc_13.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
   dm.warn = jest.fn()
 })
 
-it("warns when there's  no assignee and no WIP in the title", async () => {
+it("warns when there's no assignee and no WIP in the title", async () => {
   // When the check membership API call does not raise
   const api = { orgs: { checkMembership: () => {} } }
   dm.danger.github = { pr: { title: "My Thing", assignee: null, user: { login: "someone" } }, api }
@@ -19,7 +19,7 @@ it("warns when there's  no assignee and no WIP in the title", async () => {
   )
 })
 
-it("does not warns when someone does nto have access to the org", async () => {
+it("does not warns when someone does not have access to the org", async () => {
   // When the check membership API call does not raise
   const api = {
     orgs: {
@@ -34,13 +34,19 @@ it("does not warns when someone does nto have access to the org", async () => {
 })
 
 it("does not warn when there's there's no assignee and WIP in the title", async () => {
-  dm.danger.github = { pr: { title: "[WIP] My thing", assignee: null } }
+  dm.danger.github = { pr: { title: "[WIP] My thing", assignee: null, user: { login: "someone" } } }
   await rfc13()
   expect(dm.warn).not.toBeCalled()
 })
 
 it("does not warn when there's there's an assignee", async () => {
-  dm.danger.github = { pr: { title: "My thing", assignee: {} } }
+  dm.danger.github = { pr: { title: "My thing", assignee: {}, user: { login: "someone" } } }
+  await rfc13()
+  expect(dm.warn).not.toBeCalled()
+})
+
+it("does not warn when the PR is created by renovate", async () => {
+  dm.danger.github = { pr: { title: "My thing", assignee: null, user: { login: "renovate" } } }
   await rfc13()
   expect(dm.warn).not.toBeCalled()
 })


### PR DESCRIPTION
We're pretty consistently getting peril failures in reaction on renovate PRs where peril claims there's no assignee. Renovate adds an assignee after the PR is created and therefore tends to trip our PR rule (rfc13). 

Here's an example: https://github.com/artsy/reaction/pull/2350


Fixes #110.