### PR TITLE
Use normal import for utils

### DIFF
--- a/org/jira/pr.ts
+++ b/org/jira/pr.ts
@@ -7,6 +7,7 @@ const mergedLabels = ["merged", "monitor/qa", "monitoring/qa"]
 import { danger, peril } from "danger"
 import { PullRequest } from "github-webhook-event-types"
 import * as JiraApi from "jira-client"
+import { getJiraTicketIDsFromCommits, getJiraTicketIDsFromText, uniq, makeJiraTransition } from "./utils"
 
 import * as IssueJSON from "../../fixtures/jira_issue_example.json"
 type Issue = typeof IssueJSON
@@ -18,7 +19,6 @@ const { sentence } = danger.utils
 
 export default async (webhook: PullRequest) => {
   // Grab some util functions for Jira manipulation
-  const { getJiraTicketIDsFromCommits, getJiraTicketIDsFromText, uniq, makeJiraTransition } = await import("./utils")
   const prBody = danger.github.pr.body
 
   // Grab tickets from the PR body, and the commit messages


### PR DESCRIPTION
We got this error recently on a PR: https://github.com/artsy/reaction/pull/2355#issuecomment-490012229

## Error Error
```
Could not find './utils' as a relative import from artsy/peril-settings@org/jira/pr.ts. Does /org/jira/utils exist in the repo?
Error: Could not find './utils' as a relative import from artsy/peril-settings@org/jira/pr.ts. Does /org/jira/utils exist in the repo?
    at /opt/out/runner/customGitHubRequire.js:54:11
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```

--- 

No idea what changed to make this dynamic import suddenly fail. The paths in that error message are inconsistent and weird-looking so that probably warrants further investigation.

As a quick fix I made the import static, since there's no reason to be using a dynamic import here anyway.