### PR TITLE
Consolidate peril-settings peril rule

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -20,9 +20,6 @@
     "pull_request_review": "org/markAsMergeOnGreen.ts"
   },
   "repos": {
-    "artsy/peril-settings": {
-      "pull_request.review_requested": "org/addReviewer.ts"
-    },
     //    "artsy/metaphysics": {
     //    "pull_request": "peril/upstreamSchemaValidator.ts"
     //    },
@@ -39,7 +36,8 @@
       "pull_request": "dangerfile.ts"
     },
     "artsy/peril-settings": {
-      "pull_request": "dangerfile.ts"
+      "pull_request": "dangerfile.ts",
+      "pull_request.review_requested": "org/addReviewer.ts"
     }
   },
   "tasks": {


### PR DESCRIPTION
Doing a little one-two punch here - I'd like to use this PR to test if the review reminder implemented in [#116](https://github.com/artsy/peril-settings/pull/116) works, so please don't review this PR for a day and we'll see if you get a reminder!

And the actual content of the PR is a little thing that I missed when originally updating the `peril.settings.json` file - there was already a specific rule for the `peril-settings` repo and I added a second one. There's a chance that this will break the test because only one of them gets run, but let's see if the reminder gets sent first before jumping to that conclusion.