### PR TITLE
Use more generic names for non-forking OSS repos

### DIFF
--- a/org/ossPRsForbidForks.ts
+++ b/org/ossPRsForbidForks.ts
@@ -4,7 +4,7 @@ import { danger, warn, fail } from "danger"
 // instead of PRs from forks. Our tooling still relies on this; PRs from forks
 // won't even trigger CI builds on some of these projects, so we need to warn
 // the authors via Peril.
-const nonForkableRepos = ["eigen", "emission", "eidolon", "energy", "emergence"]
+const nonForkableRepos = ["eigen", "emission", "eidolon", "energy", "emergence", "rosalind"]
 
 export default async () => {
   const pr = danger.github.pr

--- a/org/ossPRsForbidForks.ts
+++ b/org/ossPRsForbidForks.ts
@@ -1,16 +1,16 @@
 import { danger, warn, fail } from "danger"
 
-// Mobile repos at Artsy have historically used PRs from branches on the repo,
+// Many OSS repos at Artsy have historically used PRs from branches on the repo,
 // instead of PRs from forks. Our tooling still relies on this; PRs from forks
 // won't even trigger CI builds on some of these projects, so we need to warn
 // the authors via Peril.
-const mobileRepos = ["eigen", "emission", "eidolon", "energy", "emergence"]
+const nonForkableRepos = ["eigen", "emission", "eidolon", "energy", "emergence"]
 
 export default async () => {
   const pr = danger.github.pr
-  const isMobileRepo = mobileRepos.filter(name => pr.base.repo.name.endsWith(name)).length > 0
+  const isNonForkableRepo = nonForkableRepos.filter(name => pr.base.repo.name.endsWith(name)).length > 0
 
-  if (isMobileRepo && pr.head.repo.fork) {
+  if (isNonForkableRepo && pr.head.repo.fork) {
     try {
       // Are they a member of the Artsy GitHub org? This will throw if not.
       await danger.github.api.orgs.checkMembership({ org: "artsy", username: pr.user.login })

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -8,7 +8,7 @@
     // Keep a list of all deployments in slack
     "create (ref_type == tag)": "org/newRelease.ts",
     // Jira integration
-    "pull_request": ["org/allPRs.ts", "org/jira/pr.ts", "org/mobilePRsForbidForks.ts"],
+    "pull_request": ["org/allPRs.ts", "org/jira/pr.ts", "org/ossPRsForbidForks.ts"],
     "pull_request.closed": ["org/closedPRs.ts", "org/jira/pr.ts"],
     "pull_request.opened": "org/addPatchLabel.ts",
     // The RFC process

--- a/tests/ossPRsForbidForks.test.ts
+++ b/tests/ossPRsForbidForks.test.ts
@@ -2,9 +2,9 @@ jest.mock("danger", () => jest.fn())
 import * as danger from "danger"
 const dm = danger as any
 
-import mobilePRsForbidForks from "../org/mobilePRsForbidForks"
+import ossPRsForbidForks from "../org/ossPRsForbidForks"
 
-describe("mobilePRsForbidForks", () => {
+describe("ossPRsForbidForks", () => {
   beforeEach(() => {
     dm.danger = {
       github: {
@@ -30,7 +30,7 @@ describe("mobilePRsForbidForks", () => {
     dm.fail = jest.fn()
   })
 
-  describe("on mobile repos", () => {
+  describe("on oss repos", () => {
     beforeEach(() => {
       dm.danger.github.pr.base.repo.name = "eigen"
     })
@@ -39,7 +39,7 @@ describe("mobilePRsForbidForks", () => {
       const mockCheckMembership: jest.Mock = dm.danger.github.api.orgs.checkMembership as any
       mockCheckMembership.mockImplementation(() => Promise.resolve())
       dm.danger.github.pr.head.repo.fork = true
-      await mobilePRsForbidForks()
+      await ossPRsForbidForks()
       expect(dm.fail).toHaveBeenCalled()
     })
 
@@ -47,25 +47,25 @@ describe("mobilePRsForbidForks", () => {
       const mockCheckMembership: jest.Mock = dm.danger.github.api.orgs.checkMembership as any
       mockCheckMembership.mockRejectedValueOnce("some error")
       dm.danger.github.pr.head.repo.fork = true
-      await mobilePRsForbidForks()
+      await ossPRsForbidForks()
       expect(dm.warn).toHaveBeenCalled()
     })
 
     it("does nothing when submitted from a branch", async () => {
       const mockCheckMembership: jest.Mock = dm.danger.github.api.orgs.checkMembership as any
       mockCheckMembership.mockImplementation(() => Promise.resolve())
-      await mobilePRsForbidForks()
+      await ossPRsForbidForks()
       expect(dm.fail).not.toHaveBeenCalled()
     })
   })
 
-  describe("on non-mobile repos", () => {
+  describe("on non-oss repos", () => {
     beforeEach(() => {
-      dm.danger.github.pr.base.repo.name = "force"
+      dm.danger.github.pr.base.repo.name = "gravity"
     })
 
     it("does nothing", async () => {
-      await mobilePRsForbidForks()
+      await ossPRsForbidForks()
       expect(dm.fail).not.toHaveBeenCalled()
       expect(dm.warn).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
Following up on https://github.com/artsy/README/pull/218#discussion_r292960891 …

This changes some filenames / variable names to convey that OSS repos generally (and not just mobile repos) may make use of the Peril check to warn about PRs from forks.

