### PR TITLE
Add debug for empty readmes

### DIFF
--- a/tasks/closedSourceRationaleCheck.ts
+++ b/tasks/closedSourceRationaleCheck.ts
@@ -26,6 +26,12 @@ const getInvalidRepos = async (privateRepos: Repo[]): Promise<Repo[]> => {
   })
   await Promise.all(promises)
 
+  privateRepos.forEach(repo => {
+    if (repo.readme === "") {
+      console.error(`Repo has empty readme! ${repo.name}`)
+    }
+  })
+
   const missingRepos = privateRepos.filter(repo => !repo.readme.includes(targetText))
   return missingRepos
 }


### PR DESCRIPTION
While talking through this with @ashfurrow over on https://github.com/artsy/Artsy-UIFonts/issues/9, we thought it might make sense to add this bit of troubleshooting to see if we can pinpoint what's going on here.