### PR TITLE
Add trivial label on dependabot PRs

### DIFF
--- a/org/addPatchLabel.ts
+++ b/org/addPatchLabel.ts
@@ -70,6 +70,11 @@ export default async () => {
     labelName = "Docs"
   }
 
+  // If it's a dependabot PR, make sure it gets the trivial label
+  if (danger.github.issue.labels.find(l => l.name === "dependencies")) {
+    labelName = "Version: Trivial"
+  }
+
   // Add the label
   console.log(`Adding the patch label to this PR`)
   await api.issues.addLabels({

--- a/tests/rfc_reaction_1095.test.ts
+++ b/tests/rfc_reaction_1095.test.ts
@@ -106,3 +106,17 @@ it("Uses the docs label if the PR was created by netlify cms", async () => {
   expect(mockAddLabels).toBeCalled()
   expect(mockAddLabels.mock.calls[0][0].labels).toEqual(["Docs"])
 })
+
+it("Uses the trivial label if it's a dependabot PR", async () => {
+  danger.github.issue.labels = [{ name: "dependencies" } as any]
+  mockGetLabels.mockResolvedValueOnce({
+    data: [{ name: "Version: Patch" }, { name: "Version: Trivial" }],
+  })
+  mockfileContents.mockResolvedValueOnce("{}")
+
+  await addPatchLabel()
+
+  expect(mockCreateLabel).not.toBeCalled()
+  expect(mockAddLabels).toBeCalled()
+  expect(mockAddLabels.mock.calls[0][0].labels).toEqual(["Version: Trivial"])
+})


### PR DESCRIPTION
On repos that use [auto](https://github.com/intuit/auto) we want to ensure that if the PR was created by dependabot that the PR gets assigned a `Version: Trivial` label instead of `Version: Patch`. 

Generally we don't consider dependency updates a good reason to update by themselves. This defaults to a label that won't trigger a release. 