### PR TITLE
⚠️ DO NOT MERGE YET ⚠️ Moves to hashtag #mergeongreen 

### DIFF
--- a/org/markAsMergeOnGreen.ts
+++ b/org/markAsMergeOnGreen.ts
@@ -42,7 +42,7 @@ export const rfc10 = async (issueCommentOrPrReview: IssueComment | PullRequestRe
   }
 
   // Don't do any work unless we have to
-  const keywords = ["merge on green", "merge on ci green"]
+  const keywords = ["#mergeongreen"]
   const match = keywords.find(k => text.toLowerCase().includes(k))
   if (!match) {
     return console.log(`Did not find any of the merging phrases in the comment beginning ${text.substring(0, 12)}.`)

--- a/tests/rfc_10.test.ts
+++ b/tests/rfc_10.test.ts
@@ -63,7 +63,7 @@ describe("for adding the label", () => {
 
     it("bails when the issue already has merge on green", async () => {
       await markAsMergeOnGreen({
-        comment: { body: "Merge on green", user: { login: "danger" } },
+        comment: { body: "#mergeongreen", user: { login: "danger" } },
         issue: { labels: [{ name: "Merge On Green" }], pull_request: {} },
         ...repo,
       } as any)
@@ -92,7 +92,7 @@ describe("for adding the label", () => {
       )
 
       await markAsMergeOnGreen({
-        review: { body: "Merge on green!", user: { login: "danger" } },
+        review: { body: "Looks great! #MergeOnGreen", user: { login: "danger" } },
         pull_request: pull_request,
         ...repo,
       } as any)
@@ -106,7 +106,7 @@ describe("for adding the label", () => {
 
     await markAsMergeOnGreen({
       comment: {
-        body: "Merge on green",
+        body: "#mergeongreen",
         user: { sender: { login: "orta" } },
       },
       issue: { labels: [], pull_request: {} },
@@ -137,7 +137,7 @@ describe("for handling merging when green", () => {
     expect(console.log).toBeCalledWith("Not all statuses are green")
   })
 
-  it("does nothing when the PR does not have merge on green ", async () => {
+  it("does nothing when the PR does not have merge on green", async () => {
     // Has the right status
     dm.danger.github.api.repos.getCombinedStatusForRef.mockReturnValueOnce(
       Promise.resolve({ data: { state: "success" } })
@@ -160,7 +160,7 @@ describe("for handling merging when green", () => {
     expect(console.log).toBeCalledWith("PR does not have Merge on Green")
   })
 
-  it("triggers a PR merge when there is a merge on green label ", async () => {
+  it("triggers a PR merge when there is a merge on green label", async () => {
     // Has the right status
     dm.danger.github.api.repos.getCombinedStatusForRef.mockReturnValueOnce(
       Promise.resolve({ data: { state: "success" } })


### PR DESCRIPTION
[Discussed on Slack](https://artsy.slack.com/archives/C2MEQ2HA6/p1563827563005200).

Peril reads comments and PR reviews for the phrase "merge on green" to mark a PR as needing to be merged when CI is green. The problem is, there's nothing about the phrase "merge on green" that indicates that you're directing _Peril_, instead of the engineer. 

This PR changes the words Peril search for to a hashtag: `#mergeongreen`. This hashtag format mirrors the other use of Peril looking for text:

https://github.com/artsy/peril-settings/blob/868d4ba97dbe3f268c84135abbb707b537b95a01/org/allPRs.ts#L70-L73

And we use a similar convention with Danger in a few repos, for example:

https://github.com/artsy/emission/blob/3ab51744d52cf7e4410d36e2f46c3a6019bb0a93/dangerfile.ts#L18-L20

---

This PR is marked `⚠️ DO NOT MERGE YET ⚠️` because, even though it's not important enough of a change to make an RFC, it _is_ important enough of a change to _communicate clearly_. To that end, we'll plan on the following:

- I'll mention in Slack today that this change is upcoming.
- We'll mention it again during Monday's standup.
- I'll mention it again in Slack after Monday's standup.
- Then we'll merge this PR (it will take effect immediately).

Let me know if I can clarify any of this.