### PR TITLE
@ashfurrow => Adds rule to generate nice deploy summary #FF

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -1,4 +1,5 @@
 import { danger, warn, fail } from "danger"
+import { deploySummary } from "./deploySummary"
 
 import yarn from "danger-plugin-yarn"
 
@@ -126,4 +127,5 @@ export default async () => {
   await rfc13()
   await rfc16()
   await rfc177()
+  await deploySummary()
 }

--- a/org/deploySummary.ts
+++ b/org/deploySummary.ts
@@ -1,0 +1,68 @@
+import { danger, GitHubCommit, markdown } from "danger"
+
+// Returns `true` if this is a PR to the `release` branch.
+const isRelease = () => {
+  return danger.github.pr.base.ref === "release"
+}
+
+// Map of PR's included in the deploy.
+// (will be outputted as a comment)
+interface PRInfoMap {
+  [prNumber: number]: PRInfo
+}
+// Info per PR that is included
+interface PRInfo {
+  title: string
+  href: string
+}
+// Memoized map of PR's included, and their info.
+const prMap: PRInfoMap = {}
+
+// For a given commit, will attempt to retrieve the corresponding
+// closed PR via the search API.
+const dataForCommit = async (commit: GitHubCommit) => {
+  const sha = commit.sha
+  const repo = danger.github.thisPR.repo
+  const owner = danger.github.thisPR.owner
+  const searchResponse = await danger.github.api.search.issuesAndPullRequests({
+    q: `${sha} type:pr is:closed repo:${owner}/${repo}`,
+  })
+  const prsWithCommit = searchResponse.data.items.map((i: any) => i.number) as number[]
+
+  // Assume that the only PR containing the SHA is the corresponding PR.
+  const prNumber = prsWithCommit.length && prsWithCommit[0]
+  if (!prNumber) return
+
+  // Already fetched this PR info (from an earlier commit).
+  if (prMap[prNumber]) return
+
+  const issue = await danger.github.api.issues.get({
+    owner,
+    repo,
+    number: prNumber,
+  })
+
+  // Store memoized data.
+  prMap[prNumber] = {
+    title: issue.data.title,
+    href: `https://github.com/${owner}/${repo}/${prNumber}`,
+  }
+}
+
+export const deploySummary = async () => {
+  if (!isRelease()) return
+
+  await Promise.all(danger.github.commits.map(c => dataForCommit(c)))
+
+  if (!Object.keys(prMap).length) return
+
+  const message =
+    "### This deploy contains the following PRs:\n\n" +
+    Object.entries(prMap)
+      .map(([_number, info]) => {
+        return `${info.title} (${info.href})\n`
+      })
+      .join("")
+
+  return markdown(message)
+}

--- a/tests/deploySummary.test.ts
+++ b/tests/deploySummary.test.ts
@@ -1,0 +1,61 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+dm.markdown = (message: string) => message
+
+import { deploySummary } from "../org/deploySummary"
+
+it("outputs associated PR info", async () => {
+  dm.danger = {
+    github: {
+      pr: {
+        base: {
+          ref: "release",
+        },
+      },
+      commits: [
+        {
+          sha: "sha",
+        },
+      ],
+      thisPR: {
+        title: "This awesome PR",
+        repo: "force",
+        owner: "artsy",
+        body: "",
+        base: {
+          user: {
+            login: "orta",
+          },
+          repo: {
+            name: "danger-js",
+            html_url: "http://my_url.com",
+          },
+        },
+        number: 23,
+      },
+      api: {
+        search: {
+          issuesAndPullRequests: () => {
+            return Promise.resolve({
+              data: {
+                items: [{ number: 1400 }],
+              },
+            })
+          },
+        },
+        issues: {
+          get: () => {
+            return Promise.resolve({
+              data: { title: "PR to be deployed" },
+            })
+          },
+        },
+      },
+    },
+  }
+
+  const generatedSummary = await deploySummary()
+  expect(generatedSummary).toContain("PR to be deployed (https://github.com/artsy/force/1400)")
+})


### PR DESCRIPTION
This rather aggressively adds a peril rule simultaneously with the corresponding RFC https://github.com/artsy/README/issues/238 . I forgot about our RFC process when deciding to work on this for Future Fursday 😅 .

I was able to include this rule in a sample project, and run it as a danger rule. This seemed to work and produce the desired output on deploy PR's, while skipping non-deploy PR's.

So, assuming the RFC is agreed on, this is that implementation.

I'll add some tests as well.