### PR TITLE
Format PRs to a list for easier scanning

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -179,7 +179,7 @@ export const deploySummary = async () => {
     "### This deploy contains the following PRs:\n\n" +
     Object.entries(prMap)
       .map(([_number, info]) => {
-        return `${info.title} (${info.href})\n`
+        return `- ${info.title} (${info.href})\n`
       })
       .join("")
 


### PR DESCRIPTION
Right now some of the PR summary can kind of blend together and is a little hard to scan. Turning it into a list should add a little visual separation.

Before

<img width="664" alt="image" src="https://user-images.githubusercontent.com/3087225/63122076-ea074500-bf73-11e9-8b0a-3889c7e9a6bc.png">

After

<img width="670" alt="image" src="https://user-images.githubusercontent.com/3087225/63122118-f7243400-bf73-11e9-9238-25d540b1ca5e.png">
