### PR TITLE
@zephraph => [deploySummary] Switches to use GraphQL endpoint to get all data in 1 req.

### DIFF
--- a/tests/deploySummary.test.ts
+++ b/tests/deploySummary.test.ts
@@ -36,21 +36,28 @@ it("outputs associated PR info", async () => {
         number: 23,
       },
       api: {
-        search: {
-          issuesAndPullRequests: () => {
-            return Promise.resolve({
+        request: () => {
+          return Promise.resolve({
+            data: {
               data: {
-                items: [{ number: 1400 }],
+                repository: {
+                  sha_sha: {
+                    associatedPullRequests: {
+                      edges: [
+                        {
+                          node: {
+                            title: "PR to be deployed",
+                            url: "https://github.com/artsy/force/pull/1400",
+                            number: 1400,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                },
               },
-            })
-          },
-        },
-        issues: {
-          get: () => {
-            return Promise.resolve({
-              data: { title: "PR to be deployed" },
-            })
-          },
+            },
+          })
         },
       },
     },


### PR DESCRIPTION
Good call @ashfurrow on calling out the potential perf. issue.

This switches to use the GraphQL endpoint to get all the relevant PR's, for all the included commits, in one request.

Closes https://github.com/artsy/peril-settings/issues/136