### PR TITLE
Ignore Jira tickets that are already in Done column

### DIFF
--- a/org/closedPRs.ts
+++ b/org/closedPRs.ts
@@ -1,6 +1,5 @@
-import { schedule, danger, warn, fail, peril } from "danger"
+import { danger, peril } from "danger"
 import { IncomingWebhook } from "@slack/client"
-import { PullRequest, Issues } from "github-webhook-event-types"
 
 // Ping slack channels for related labels
 // https://github.com/artsy/peril-settings/issues/33
@@ -11,7 +10,7 @@ export default async () => {
   const labelsMap = {
     consignments: "C52403S10",
     auctions: "C0C4AJ1PF",
-    analytics: "C0KEQD4B0"
+    analytics: "C0KEQD4B0",
   } as any
 
   // Find the labels in both the map above, and in the PR's labels

--- a/org/jira/pr.ts
+++ b/org/jira/pr.ts
@@ -3,7 +3,7 @@
 const companyPrefix = "artsyproduct"
 const wipLabels = ["in review", "in progress", "review"]
 const mergedLabels = ["merged", "monitor/qa", "monitoring/qa"]
-const ignoredStatuses = ["done"]
+const ignoredStatuses = ["done", "closed"]
 
 import { danger, peril } from "danger"
 import { PullRequest } from "github-webhook-event-types"

--- a/org/jira/pr.ts
+++ b/org/jira/pr.ts
@@ -3,6 +3,7 @@
 const companyPrefix = "artsyproduct"
 const wipLabels = ["in review", "in progress", "review"]
 const mergedLabels = ["merged", "monitor/qa", "monitoring/qa"]
+const ignoredStatuses = ["done"]
 
 import { danger, peril } from "danger"
 import { PullRequest } from "github-webhook-event-types"
@@ -49,6 +50,14 @@ export default async (webhook: PullRequest) => {
       // https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-issue-issueIdOrKey-get
 
       const issue: Issue = (await jira.findIssue(ticketID)) as any
+
+      const currentStatusName = issue.fields.status.name
+
+      if (ignoredStatuses.includes(currentStatusName.toLowerCase())) {
+        // This Jira ticket is already in status that we don't want to move
+        console.log(`Ignored moving ${issue.key}, its in ${currentStatusName}`)
+        return
+      }
 
       // Figure out what we want to move it to
       const labelsToLookFor = danger.github.pr.merged ? mergedLabels : wipLabels


### PR DESCRIPTION
# Problem
We've started seeing tickets that are already one, go back to merged column when they get deployed.

# Solution
Ignore moving `done` and `closed` tickets.