### PR TITLE
[OCWG-25] Moves standup responsibility to an engineer who is leaving on-call

### DIFF
--- a/tasks/standupReminder.ts
+++ b/tasks/standupReminder.ts
@@ -10,7 +10,7 @@ export default async () => {
 }
 
 export const emailsFromOpsGenie = async (today = new Date()) => {
-  const targetDate = new Date(today.getTime() + 3600 * 24 * 1000)
+  const targetDate = new Date(today.getTime())
   const qs = querystring.stringify({ date: targetDate.toISOString() })
   const url = `https://api.opsgenie.com/v2/schedules/${peril.env.OPSGENIE_SCHEDULE_ID}/on-calls?${qs}`
   const req = await fetch(url, {

--- a/tasks/standupReminder.ts
+++ b/tasks/standupReminder.ts
@@ -45,6 +45,6 @@ export const sendMessageForEmails = async (emails: string[]) => {
   await slackMessage(
     `${onCallStaffMentions.join(
       ", "
-    )} it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md`
+    )} based on our on-call schedule, you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md Add new standup notes here: https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c`
   )
 }

--- a/tests/standupReminder.test.ts
+++ b/tests/standupReminder.test.ts
@@ -75,8 +75,8 @@ describe("Monday standup reminders", () => {
       const emails = await emailsFromOpsGenie(new Date(today))
 
       await sendMessageForEmails(emails)
-      expect(receivedMessage).toEqual(
-        "<@ORTAID>, <@ASHID> it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md"
+      expect(receivedMessage).toMatchInlineSnapshot(
+        `"<@ORTAID>, <@ASHID> based on our on-call schedule, you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md Add new standup notes here: https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c"`
       )
     })
   })
@@ -99,8 +99,8 @@ describe("Monday standup reminders", () => {
       const emails = await emailsFromOpsGenie(new Date(today))
 
       await sendMessageForEmails(emails)
-      expect(receivedMessage).toEqual(
-        "<@ASHID> it looks like you are on-call this week, so you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md"
+      expect(receivedMessage).toMatchInlineSnapshot(
+        `"<@ASHID> based on our on-call schedule, you’ll be running the Monday standup at 11:30 NYC time. Here are the docs: https://github.com/artsy/README/blob/master/events/open-standup.md Add new standup notes here: https://www.notion.so/artsy/Standup-Notes-28a5dfe4864645788de1ef936f39687c"`
       )
     })
   })


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/OCWG-25 to move responsibility for running standup to the engineer _leaving_ on call, instead of both engineers _currently_ on call. 

@xtina-starr this means you'll be running next week's standup as well 🌟 

There were no unit tests to update for this change. We were previously rolling ahead a day to find out who was going to be on-call, so we just took that roll ahead out. 