### PR TITLE
Rename compareReactionSchema -> compareForceSchema

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -21,7 +21,7 @@
   },
   "repos": {
     "artsy/metaphysics": {
-      "pull_request": "peril/compareReactionSchema.ts"
+      "pull_request": "peril/compareForceSchema.ts"
     },
     "artsy/reaction": {
       "pull_request": "danger/pr.ts"


### PR DESCRIPTION
Problem

In https://github.com/artsy/metaphysics/pull/2437/commits/39b06c0a955a7a036312003ac0765658497852ef, we updated our MP tooling so that we compare against the Force GraphQL schema, instead of Reaction's, now that Reaction has been merged into Force. 

As such, recent MP PRs have had breaking building due to peril-artsy not being able to find compareReactionSchema, for example: https://github.com/artsy/metaphysics/pull/2438

Moreover, whatever value that this comparison script is providing is minimized as the script wasn't running.

Solution

* Rename script in peril settings