### PR TITLE
feat: warn when semantic formatting not detected in PR title

### DIFF
--- a/org/rfc_237.ts
+++ b/org/rfc_237.ts
@@ -1,0 +1,15 @@
+import { danger, markdown } from "danger"
+
+const semanticFormat = /^(fix|feat|build|chore|ci|docs|style|refactor|perf|test)(?:\(.+\))?!?:.+$/
+
+// Nudge PR authors to use semantic commit formatting
+// https://github.com/artsy/README/issues/327
+export const rfc327 = () => {
+  const pr = danger.github.pr
+
+  if (!semanticFormat.test(pr.title)) {
+    return markdown(
+      "Hi there! :wave:\n\nWe're trialing semantic commit formatting which has not been detected in your PR title\n\nRefer to [this RFC](https://github.com/artsy/README/issues/327#issuecomment-698842527) and [Conventional Commits](https://www.conventionalcommits.org)for PR/commit formatting guidelines."
+    )
+  }
+}

--- a/peril.settings.json
+++ b/peril.settings.json
@@ -36,7 +36,7 @@
       "pull_request": "dangerfile.ts"
     },
     "artsy/peril-settings": {
-      "pull_request": "dangerfile.ts"
+      "pull_request": ["dangerfile.ts", "org/rfc_237.ts"]
       // "pull_request.review_requested": "org/addReviewer.ts"
     }
   },

--- a/tests/rfc_327.test.ts
+++ b/tests/rfc_327.test.ts
@@ -1,0 +1,44 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import { rfc327 } from "../org/rfc_237"
+
+describe("rfc327", () => {
+  beforeEach(() => {
+    dm.danger = {
+      github: {
+        pr: {
+          title: "",
+        },
+      },
+    }
+    dm.markdown = jest.fn()
+  })
+
+  describe("when a PR title matches semantic formatting", () => {
+    it("does nothing", async () => {
+      dm.danger.github.pr.title = "feat: add awesome new feature"
+      await rfc327()
+      expect(dm.markdown).not.toHaveBeenCalled()
+
+      // Includes optional scope
+      dm.danger.github.pr.title = "fix(scope): add awesome new feature"
+      await rfc327()
+      expect(dm.markdown).not.toHaveBeenCalled()
+
+      // Accepts breaking change signifier
+      dm.danger.github.pr.title = "chore!: some breaking change"
+      await rfc327()
+      expect(dm.markdown).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when a PR title does not match semantic formatting", () => {
+    it("warns the PR author and links to the RFC", async () => {
+      dm.danger.github.pr.title = "Does not match semantic formatting"
+      await rfc327()
+      expect(dm.markdown).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Link to RFC: https://github.com/artsy/README/issues/327 and Conventional Commits: https://www.conventionalcommits.org

Planning to test this out with one repository (TBD: maybe this repository, peril-settings).

Also thinking of extending this rule to include PR commit linting as an alternative to using semantic formatting in the PR title.