### PR TITLE
chore: Add default export to rfc_327

### DIFF
--- a/org/rfc_237.ts
+++ b/org/rfc_237.ts
@@ -13,3 +13,5 @@ export const rfc327 = () => {
     )
   }
 }
+
+export default rfc327


### PR DESCRIPTION
I don't think this check is picked up correctly by Peril without this default export defined.