### PR TITLE
chore: remove monday informationals scheduled task

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -54,7 +54,6 @@
   },
   "scheduler": {
     "daily": "daily-license-check",
-    "monday-morning-est": "monday-informationals",
     "thursday-morning-est": "simple-sups"
   }
 }


### PR DESCRIPTION
Experimenting with a GitHub Action + Artsy CLI approach.

- https://github.com/artsy/README/pull/367
- https://github.com/artsy/artsy-cli/pull/24