### PR TITLE
feat: Validate PR description Changelogs on Eigen

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -1,6 +1,8 @@
 import { danger, warn, fail, GitHubCommit, markdown } from "danger"
-
 import yarn from "danger-plugin-yarn"
+import { ParseResult as PRDescriptionParseResult, ParseResult } from "./helpers/changelog/changelog-types"
+// @ts-ignore
+import { parsePRDescription } from "./helpers/changelog/parsePRDescription.js"
 
 // "Highlight package dependencies on Node projects"
 const rfc1 = async () => {
@@ -8,6 +10,7 @@ const rfc1 = async () => {
 }
 
 import spellcheck from "danger-plugin-spellcheck"
+import { isEqual } from "lodash"
 // "Keep our Markdown documents awesome",
 const rfc2 = async () => {
   await spellcheck({ settings: "artsy/peril-settings@spellcheck.json" })
@@ -27,17 +30,17 @@ export const rfc5 = () => {
 export const rfc7 = async () => {
   const pr = danger.github.thisPR
   const commitLabels: string[] = danger.git.commits
-    .map(c => c.message)
-    .filter(m => m.startsWith("[") && m.includes("]"))
-    .map(m => (m.match(/\[(.*)\]/) as any)[1]) // Guaranteed to match based on filter above.
+    .map((c) => c.message)
+    .filter((m) => m.startsWith("[") && m.includes("]"))
+    .map((m) => (m.match(/\[(.*)\]/) as any)[1]) // Guaranteed to match based on filter above.
 
   if (commitLabels.length > 0) {
     const api = danger.github.api
     const githubLabels = await api.issues.listLabelsForRepo({ owner: pr.owner, repo: pr.repo })
     const matchingLabels = githubLabels.data
-      .map(l => l.name)
-      .filter(l => commitLabels.find(cl => l === cl))
-      .filter(l => !danger.github.issue.labels.find(label => label.name === l))
+      .map((l) => l.name)
+      .filter((l) => commitLabels.find((cl) => l === cl))
+      .filter((l) => !danger.github.issue.labels.find((label) => label.name === l))
 
     if (matchingLabels.length > 0) {
       await api.issues.addLabels({ owner: pr.owner, repo: pr.repo, number: pr.number, labels: matchingLabels })
@@ -97,8 +100,8 @@ export const rfc16 = async () => {
   if (isOpen && hasChangelog) {
     const files = [...danger.git.modified_files, ...danger.git.created_files]
 
-    const hasCodeChanges = files.find(file => !file.match(/(test|spec)/i))
-    const hasChangelogChanges = files.find(file => changelogs.includes(file))
+    const hasCodeChanges = files.find((file) => !file.match(/(test|spec)/i))
+    const hasChangelogChanges = files.find((file) => changelogs.includes(file))
 
     if (hasCodeChanges && !hasChangelogChanges) {
       warn(
@@ -166,7 +169,7 @@ export const deploySummary = async () => {
 
   const repo = danger.github.thisPR.repo
   const owner = danger.github.thisPR.owner
-  const fragments = danger.github.commits.map(c => fragmentForCommit(c)).join("")
+  const fragments = danger.github.commits.map((c) => fragmentForCommit(c)).join("")
   const query = `
     {
       repository(owner: "${owner}", name: "${repo}") {
@@ -211,6 +214,19 @@ export const deploySummary = async () => {
       .join("")
 
   return markdown(message)
+}
+
+// Require changelog on Eigen PRs to match to be valid
+// See Eigen RFC: https://github.com/artsy/eigen/issues/4499
+// TODO: change this
+export const rfc179 = async () => {
+  const pr = danger.github.pr
+  const repoName = pr.base.repo.name
+
+  if (repoName !== "eigen") {
+    console.log("Skipping this check because the active repo is not Eigen")
+    return
+  }
 }
 
 // The default run

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -238,6 +238,12 @@ export const rfc179 = () => {
   const content = pr.body
 
   const res = parsePRDescription(content) as ParseResult
+
+  // TODO: Delete this once we finish the new changelog work
+  if (!content.includes("#run_new_changelog_check")) {
+    return
+  }
+
   if (res.type === "error") {
     console.log("Something went wrong while parsing the PR description")
     warn("❌ **An error occurred while validating your changelog, please make sure you provided a valid changelog.**")
@@ -276,6 +282,6 @@ export default async () => {
   await rfc13()
   await rfc16()
   await rfc177()
-  await rfc179()
+  rfc179()
   await deploySummary()
 }

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -244,6 +244,14 @@ export const rfc179 = async () => {
     warn("❌ **An error occurred while validating your changelog, please make sure you provided a valid changelog.**")
     return
   }
+
+  const NO_CHANGES: PRDescriptionParseResult = { type: "no_changes" }
+
+  if (isEqual(res, NO_CHANGES)) {
+    console.log("PR has no changes")
+    warn("✅ **No changelog changes**")
+    return
+  }
 }
 
 // The default run

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -233,6 +233,17 @@ export const rfc179 = async () => {
     console.log("Skipping this check because the PR is not open")
     return
   }
+
+  const ERROR: PRDescriptionParseResult = { type: "error" }
+
+  const content = pr.body
+
+  const res = parsePRDescription(content) as ParseResult
+  if (isEqual(res, ERROR)) {
+    console.log("Something went wrong while parsing the PR description")
+    warn("❌ **An error occurred while validating your changelog, please make sure you provided a valid changelog.**")
+    return
+  }
 }
 
 // The default run

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -219,7 +219,7 @@ export const deploySummary = async () => {
 
 // Require changelog on Eigen PRs to match to be valid
 // See Eigen RFC: https://github.com/artsy/eigen/issues/4499
-// TODO: change this
+// Peril related RFC: https://github.com/artsy/peril-settings/issues/182
 export const rfc179 = () => {
   const pr = danger.github.pr
   const repoName = pr.base.repo.name
@@ -276,5 +276,6 @@ export default async () => {
   await rfc13()
   await rfc16()
   await rfc177()
+  await rfc179()
   await deploySummary()
 }

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -227,6 +227,12 @@ export const rfc179 = async () => {
     console.log("Skipping this check because the active repo is not Eigen")
     return
   }
+
+  const isOpen = pr.state === "open"
+  if (!isOpen) {
+    console.log("Skipping this check because the PR is not open")
+    return
+  }
 }
 
 // The default run

--- a/org/helpers/changelog/changelog-types.d.ts
+++ b/org/helpers/changelog/changelog-types.d.ts
@@ -1,0 +1,10 @@
+export type ParseResult =
+  | { type: "error" } // for when no changelog-related stuff is found
+  | { type: "no_changes" } // for when we add #nochangelog hashtag
+  | {
+      type: "changes"
+      crossPlatformUserFacingChanges: string[]
+      iOSUserFacingChanges: string[]
+      androidUserFacingChanges: string[]
+      devChanges: string[]
+    }

--- a/org/helpers/changelog/generateChangelogSectionTemplate.js
+++ b/org/helpers/changelog/generateChangelogSectionTemplate.js
@@ -1,0 +1,53 @@
+// @ts-check
+
+const changelogTemplateSections = {
+  crossPlatformUserFacingChanges: "Cross-platform user-facing changes",
+  iOSUserFacingChanges: "iOS user-facing changes",
+  androidUserFacingChanges: "Android user-facing changes",
+  devChanges: "Dev changes",
+}
+
+module.exports.changelogTemplateSections = changelogTemplateSections
+
+module.exports.generateChangelogSectionTemplate = () => {
+  return `### Changelog updates
+
+<!-- 📝 Please fill out at least one of these sections. -->
+<!-- ⓘ 'User-facing' changes will be published as release notes. -->
+<!-- ⌫ Feel free to remove sections that don't apply. -->
+<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
+<!-- 🤷‍♂️ Replace this entire block with the hashtag \`#nochangelog\` to avoid updating the changelog. -->
+${Object.entries(changelogTemplateSections)
+  .map(([, title]) => "#### " + title)
+  .join("\n-\n")}
+-
+
+<!-- end_changelog_updates -->
+`
+}
+
+const fs = require("fs")
+const prettier = require("prettier")
+
+/**
+ * @param {string} filePath
+ */
+module.exports.updateChangelogSectionTemplate = (filePath) => {
+  let fileContents = fs.readFileSync(filePath, "utf8").toString()
+
+  const regex = /### Changelog updates[\S\s]+end_changelog_updates.*/g
+  if (!fileContents.match(regex)) {
+    console.error("Can't find 'Changelog updates' section in pull request template", filePath)
+    process.exit(1)
+  }
+
+  fileContents = fileContents.replace(regex, this.generateChangelogSectionTemplate())
+  fileContents = prettier.format(fileContents, { parser: "markdown" })
+
+  fs.writeFileSync(filePath, fileContents, "utf8")
+}
+
+// @ts-ignore
+if (require.main === module) {
+  this.updateChangelogSectionTemplate("./docs/pull_request_template.md")
+}

--- a/org/helpers/changelog/parsePRDescription-tests.ts
+++ b/org/helpers/changelog/parsePRDescription-tests.ts
@@ -1,0 +1,191 @@
+import { ParseResult as PRDescriptionParseResult } from "./changelog-types"
+// @ts-ignore
+import { parsePRDescription } from "./parsePRDescription"
+
+const ERROR: PRDescriptionParseResult = { type: "error" }
+const NO_CHANGES: PRDescriptionParseResult = { type: "no_changes" }
+
+describe("parsePRDescription", () => {
+  it("returns error for empty PR description", () => {
+    expect(parsePRDescription("")).toEqual(ERROR)
+  })
+
+  it("returns error for PR description that does not contain any changelog info", () => {
+    expect(
+      parsePRDescription(`
+# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+    `)
+    ).toEqual(ERROR)
+  })
+
+  it("returns no_changes when the user includes '#nochangelog' hashtag", () => {
+    expect(
+      parsePRDescription(`
+# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+
+#nochangelog
+    `)
+    ).toEqual(NO_CHANGES)
+  })
+
+  it("returns error when no changes have been declared and #nochangelog has not been included", () => {
+    expect(
+      parsePRDescription(`
+# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+### Changelog updates
+
+<!-- 📝 Please fill out at least one of these sections. -->
+<!-- ⓘ 'User-facing' changes will be published as release notes. -->
+<!-- ⌫ Feel free to remove sections that don't apply. -->
+<!-- • Write a markdown list or just a single paragraph, but stick to plain text. -->
+<!-- 🤷‍♂️ Replace this entire block with the hashtag \`#nochangelog\` to avoid updating the changelog. -->
+
+#### Cross-platform user-facing changes
+-
+#### iOS user-facing changes
+-
+#### Android user-facing changes
+-
+#### Dev changes
+-
+
+### Other stuff
+      `)
+    ).toEqual(ERROR)
+  })
+
+  it("returns any changes specified by the PR author", () => {
+    expect(
+      parsePRDescription(`
+# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+### Changelog updates
+
+#### Cross-platform user-facing changes
+- Added a new button
+  for the checkout flow
+- Fixed modal close button
+#### iOS user-facing changes
+- Fixed input focus styles
+#### Android user-facing changes
+Updated splash screen color
+#### Dev changes
+- Improved changelog tooling
+- Upgraded lodash
+
+### Other stuff
+
+blah
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "androidUserFacingChanges": Array [
+          "Updated splash screen color",
+        ],
+        "crossPlatformUserFacingChanges": Array [
+          "Added a new button
+      for the checkout flow",
+          "Fixed modal close button",
+        ],
+        "devChanges": Array [
+          "Improved changelog tooling",
+          "Upgraded lodash",
+        ],
+        "iOSUserFacingChanges": Array [
+          "Fixed input focus styles",
+        ],
+        "type": "changes",
+      }
+    `)
+  })
+
+  it("allows sections of the changelog to be deleted", () => {
+    expect(
+      parsePRDescription(`
+### Description
+blah blah
+
+### Changelog updates
+
+#### iOS user-facing changes
+- Fixed input focus styles
+
+### Other stuff
+
+blah
+      `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "androidUserFacingChanges": Array [],
+        "crossPlatformUserFacingChanges": Array [],
+        "devChanges": Array [],
+        "iOSUserFacingChanges": Array [
+          "Fixed input focus styles",
+        ],
+        "type": "changes",
+      }
+    `)
+  })
+
+  it("supports single-level markdown lists", () => {
+    expect(
+      parsePRDescription(`
+### Changelog updates
+
+#### iOS user-facing changes
+- Fixed input focus styles
+- Added things
+- Removed things
+- Updated things
+    `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "androidUserFacingChanges": Array [],
+        "crossPlatformUserFacingChanges": Array [],
+        "devChanges": Array [],
+        "iOSUserFacingChanges": Array [
+          "Fixed input focus styles",
+          "Added things",
+          "Removed things",
+          "Updated things",
+        ],
+        "type": "changes",
+      }
+    `)
+  })
+
+  it("supports paragraphs of text", () => {
+    expect(
+      parsePRDescription(`
+### Changelog updates
+
+#### iOS user-facing changes
+made the modals close a bit faster
+by updating the transition gradient
+
+uses a trampoline to avoid the problem
+where the click didn't work
+    `)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "androidUserFacingChanges": Array [],
+        "crossPlatformUserFacingChanges": Array [],
+        "devChanges": Array [],
+        "iOSUserFacingChanges": Array [
+          "made the modals close a bit faster
+      by updating the transition gradient",
+          "uses a trampoline to avoid the problem
+      where the click didn't work",
+        ],
+        "type": "changes",
+      }
+    `)
+  })
+})

--- a/org/helpers/changelog/parsePRDescription.js
+++ b/org/helpers/changelog/parsePRDescription.js
@@ -1,0 +1,97 @@
+// @ts-check
+
+const { changelogTemplateSections } = require("./generateChangelogSectionTemplate")
+
+/**
+ * @param {string} description
+ * @returns {import('./changelog-types').ParseResult}
+ */
+module.exports.parsePRDescription = (description) => {
+  description = stripComments(description)
+  if (description.includes("#nochangelog")) {
+    return { type: "no_changes" }
+  }
+
+  const lines = description.split("\n")
+
+  /**
+   * @type {import('./changelog-types').ParseResult}
+   */
+  const result = {
+    type: "changes",
+    androidUserFacingChanges: [],
+    crossPlatformUserFacingChanges: [],
+    devChanges: [],
+    iOSUserFacingChanges: [],
+  }
+
+  for (const [sectionKey, sectionTitle] of Object.entries(changelogTemplateSections)) {
+    let i = lines.indexOf("#### " + sectionTitle)
+    if (i === -1) {
+      continue
+    }
+    i++
+    // either a single text paragraph or a list
+    const sectionLines = []
+    while (i < lines.length && lines[i].match(/^( *\w|-[\w ]|\*[\w ]|\s*$)/)) {
+      sectionLines.push(lines[i])
+      i++
+    }
+    result[sectionKey] = groupItems(sectionLines)
+  }
+
+  if (
+    result.androidUserFacingChanges.length === 0 &&
+    result.crossPlatformUserFacingChanges.length === 0 &&
+    result.devChanges.length === 0 &&
+    result.iOSUserFacingChanges.length === 0
+  ) {
+    return { type: "error" }
+  }
+
+  return result
+}
+
+/**
+ * @param {string} text
+ */
+function stripComments(text) {
+  return text.replace(/<!--.*?-->/g, "")
+}
+
+/**
+ * @param {string[]} lines
+ */
+function groupItems(lines) {
+  /**
+   * @type {string[]}
+   */
+  const result = []
+
+  /**
+   * @type {string[]}
+   */
+  let group = []
+
+  for (const line of lines) {
+    if (line.startsWith("-") || line.startsWith("*")) {
+      if (group.length) {
+        result.push(group.join("\n"))
+      }
+      group = [line.slice(1).trim()]
+    } else if (line.match(/^\s*$/)) {
+      // paragraph
+      if (group.length) {
+        result.push(group.join("\n"))
+      }
+      group = []
+    } else {
+      group.push(line.trim())
+    }
+  }
+  if (group.length) {
+    result.push(group.join("\n"))
+  }
+
+  return result
+}

--- a/tests/rfc_179.test.ts
+++ b/tests/rfc_179.test.ts
@@ -41,4 +41,10 @@ describe("RFC: 179", () => {
       "❌ **An error occurred while validating your changelog, please make sure you provided a valid changelog.**"
     )
   })
+
+  it("warns the author when no changelog changes were detected", () => {
+    dm.danger.github = { pr: { body: "#nochangelog", base: { repo: { name: "eigen" } }, state: "open" } }
+    rfc179()
+    expect(dm.warn).toHaveBeenCalledWith("✅ **No changelog changes**")
+  })
 })

--- a/tests/rfc_179.test.ts
+++ b/tests/rfc_179.test.ts
@@ -36,7 +36,9 @@ describe("RFC: 179", () => {
   })
 
   it("warns the author when the PR body is invalid", () => {
-    dm.danger.github = { pr: { body: "invalid body", base: { repo: { name: "eigen" } }, state: "open" } }
+    dm.danger.github = {
+      pr: { body: "#run_new_changelog_check invalid body", base: { repo: { name: "eigen" } }, state: "open" },
+    }
     rfc179()
     expect(dm.warn).toHaveBeenCalledWith(
       "❌ **An error occurred while validating your changelog, please make sure you provided a valid changelog.**"
@@ -44,7 +46,9 @@ describe("RFC: 179", () => {
   })
 
   it("warns the author when no changelog changes were detected", () => {
-    dm.danger.github = { pr: { body: "#nochangelog", base: { repo: { name: "eigen" } }, state: "open" } }
+    dm.danger.github = {
+      pr: { body: "#run_new_changelog_check #nochangelog", base: { repo: { name: "eigen" } }, state: "open" },
+    }
     rfc179()
     expect(dm.warn).toHaveBeenCalledWith("✅ **No changelog changes**")
   })
@@ -55,6 +59,7 @@ describe("RFC: 179", () => {
         body: `# Description
 
 This pull request adds some stuff to the thing so that it can blah.
+#run_new_changelog_check
 ### Changelog updates
 
 #### Cross-platform user-facing changes

--- a/tests/rfc_179.test.ts
+++ b/tests/rfc_179.test.ts
@@ -1,0 +1,22 @@
+jest.mock("danger", () => jest.fn())
+import * as danger from "danger"
+const dm = danger as any
+
+import { rfc179 } from "../org/allPRs"
+
+jest.spyOn(console, "log").mockImplementation()
+
+const warnMock = jest.fn()
+beforeEach(() => {
+  dm.danger = {}
+  dm.warn = warnMock
+  console.log = jest.fn()
+})
+
+describe("RFC: 179", () => {
+  it("bails when it's not running on eigen", () => {
+    dm.danger.github = { pr: { base: { repo: { name: "force" } } } }
+    rfc179()
+    expect(console.log).toHaveBeenCalledWith("Skipping this check because the active repo is not Eigen")
+  })
+})

--- a/tests/rfc_179.test.ts
+++ b/tests/rfc_179.test.ts
@@ -33,4 +33,12 @@ describe("RFC: 179", () => {
     rfc179()
     expect(console.log).toHaveBeenCalledWith("Skipping this check because the PR is not open")
   })
+
+  it("warns the author when the PR body is invalid", () => {
+    dm.danger.github = { pr: { body: "invalid body", base: { repo: { name: "eigen" } }, state: "open" } }
+    rfc179()
+    expect(dm.warn).toHaveBeenCalledWith(
+      "❌ **An error occurred while validating your changelog, please make sure you provided a valid changelog.**"
+    )
+  })
 })

--- a/tests/rfc_179.test.ts
+++ b/tests/rfc_179.test.ts
@@ -9,6 +9,7 @@ jest.spyOn(console, "log").mockImplementation()
 const warnMock = jest.fn()
 beforeEach(() => {
   dm.danger = {}
+  dm.markdown = (message: string) => message
   dm.warn = warnMock
   console.log = jest.fn()
 })
@@ -46,5 +47,44 @@ describe("RFC: 179", () => {
     dm.danger.github = { pr: { body: "#nochangelog", base: { repo: { name: "eigen" } }, state: "open" } }
     rfc179()
     expect(dm.warn).toHaveBeenCalledWith("✅ **No changelog changes**")
+  })
+
+  it("returns the list of changes detected", () => {
+    dm.danger.github = {
+      pr: {
+        body: `# Description
+
+This pull request adds some stuff to the thing so that it can blah.
+### Changelog updates
+
+#### Cross-platform user-facing changes
+- Added a new button
+  for the checkout flow
+- Fixed modal close button
+#### iOS user-facing changes
+- Fixed input focus styles
+#### Android user-facing changes
+Updated splash screen color
+#### Dev changes
+- Improved changelog tooling
+- Upgraded lodash
+
+### Other stuff
+
+blah`,
+        base: { repo: { name: "eigen" } },
+        state: "open",
+      },
+    }
+    const res = rfc179()
+    expect(res).toEqual(
+      `### This PR contains the following changes:
+
+- Android user-facing changes (Updated splash screen color)
+- Cross-platform user-facing changes (Added a new button
+for the checkout flow,Fixed modal close button)
+- Dev changes (Improved changelog tooling,Upgraded lodash)
+- iOS user-facing changes (Fixed input focus styles)`
+    )
   })
 })

--- a/tests/rfc_179.test.ts
+++ b/tests/rfc_179.test.ts
@@ -19,4 +19,18 @@ describe("RFC: 179", () => {
     rfc179()
     expect(console.log).toHaveBeenCalledWith("Skipping this check because the active repo is not Eigen")
   })
+
+  it("bails when the PR is not open", () => {
+    dm.danger.github = { pr: { base: { repo: { name: "eigen" } }, state: "closed" } }
+    rfc179()
+    expect(console.log).toHaveBeenCalledWith("Skipping this check because the PR is not open")
+
+    dm.danger.github = { pr: { base: { repo: { name: "eigen" } }, state: "locked" } }
+    rfc179()
+    expect(console.log).toHaveBeenCalledWith("Skipping this check because the PR is not open")
+
+    dm.danger.github = { pr: { base: { repo: { name: "eigen" } }, state: "merged" } }
+    rfc179()
+    expect(console.log).toHaveBeenCalledWith("Skipping this check because the PR is not open")
+  })
 })


### PR DESCRIPTION
This PR resolves the following RFC: [Validate PR description Changelogs on Eigen](https://github.com/artsy/peril-settings/issues/182)

In order to not break our current workflows in Eigen, this rule will be temporarily running only on Eigen PRs containing `#run_new_changelog_check` in the PR body. Once we finish the remaining work on Eigen, we can safely enable it again for all PRs in Eigen.