### PR TITLE
feat: Enable conventional commits for titles on Eigen

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -227,7 +227,7 @@ export const rfc327 = () => {
   const pr = danger.github.pr
   const repoName = pr.base.repo.name
 
-  if (["peril-settings", "volt"].includes(repoName) && !semanticFormat.test(pr.title)) {
+  if (["peril-settings", "volt", "eigen"].includes(repoName) && !semanticFormat.test(pr.title)) {
     return markdown(
       "Hi there! :wave:\n\nWe're trialing semantic commit formatting which has not been detected in your PR title.\n\nRefer to [this RFC](https://github.com/artsy/README/issues/327#issuecomment-698842527) and [Conventional Commits](https://www.conventionalcommits.org) for PR/commit formatting guidelines."
     )

--- a/tests/rfc_327.test.ts
+++ b/tests/rfc_327.test.ts
@@ -33,7 +33,12 @@ describe("rfc327", () => {
       expect(dm.markdown).not.toHaveBeenCalled()
 
       // Accepts breaking change signifier
-      dm.danger.github.pr.title = "chore!: some breaking change"
+      dm.danger.github.pr.title = "feat(CX-134): some breaking change"
+      await rfc327()
+      expect(dm.markdown).not.toHaveBeenCalled()
+
+      // Accepts breaking change signifier
+      dm.danger.github.pr.title = "chore(Auctions): some small task"
       await rfc327()
       expect(dm.markdown).not.toHaveBeenCalled()
     })


### PR DESCRIPTION
This comes as a follow-up from our Knowledge share yesterday.