### PR TITLE
chore: remove RFC link from automated Peril semantic commit formatting comment

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -229,7 +229,7 @@ export const rfc327 = () => {
 
   if (["peril-settings", "volt", "eigen"].includes(repoName) && !semanticFormat.test(pr.title)) {
     return markdown(
-      "Hi there! :wave:\n\nWe're trialing semantic commit formatting which has not been detected in your PR title.\n\nRefer to [this RFC](https://github.com/artsy/README/issues/327#issuecomment-698842527) and [Conventional Commits](https://www.conventionalcommits.org) for PR/commit formatting guidelines."
+      "Hi there! :wave:\n\nWe're trialing semantic commit formatting which has not been detected in your PR title.\n\nRefer to artsy/README#327 and [Conventional Commits](https://www.conventionalcommits.org) for PR/commit formatting guidelines."
     )
   }
 }


### PR DESCRIPTION
This link to the original RFC creates a lot of noise on the [GitHub issue][issue]. This commit removes the link to eliminate that noise.

[issue]: https://github.com/artsy/README/issues/327

cc/ @admbtlr @patrinoua 