### PR TITLE
chore: really remove the link to README#327 RFC

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -229,7 +229,7 @@ export const rfc327 = () => {
 
   if (["peril-settings", "volt", "eigen"].includes(repoName) && !semanticFormat.test(pr.title)) {
     return markdown(
-      "Hi there! :wave:\n\nWe're trialing semantic commit formatting which has not been detected in your PR title.\n\nRefer to artsy/README#327 and [Conventional Commits](https://www.conventionalcommits.org) for PR/commit formatting guidelines."
+      "Hi there! :wave:\n\nWe're trialing semantic commit formatting which has not been detected in your PR title.\n\nRefer to README#327 and [Conventional Commits](https://www.conventionalcommits.org) for PR/commit formatting guidelines."
     )
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/artsy/peril-settings/pull/194 which still creates an undesired backlink on the original RFC GitHub issue.