### PR TITLE
fix: disable semantic commit check on Deploy PRs

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -227,13 +227,9 @@ export const rfc327 = () => {
   const pr = danger.github.pr
   const repoName = pr.base.repo.name
 
-  if ([
-    "eigen",
-    "force",
-    "palette",
-    "peril-settings",
-    "volt",
-  ].includes(repoName) && !semanticFormat.test(pr.title)) {
+  const SUPPORTED_REPOS = ["eigen", "force", "palette", "peril-settings", "volt"]
+
+  if (SUPPORTED_REPOS.includes(repoName) && !semanticFormat.test(pr.title) && pr.title !== "Deploy") {
     return markdown(
       "Hi there! :wave:\n\nWe're trialing semantic commit formatting which has not been detected in your PR title.\n\nRefer to README#327 and [Conventional Commits](https://www.conventionalcommits.org) for PR/commit formatting guidelines."
     )


### PR DESCRIPTION
This PR disables semantic commit check on Deploy PRs

The goal is to avoid this type of message
<img width="923" alt="Screenshot 2022-10-21 at 12 55 08" src="https://user-images.githubusercontent.com/11945712/197180245-70ac2efe-5da3-4559-b3c2-cee12c0200d6.png">
