### PR TITLE
feat: conventional commits everywhere

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -219,7 +219,7 @@ export const deploySummary = async () => {
   return markdown(message)
 }
 
-// Nudge PR authors to use semantic commit formatting
+// Enforce semantic commit formatting in pr titles
 // https://github.com/artsy/README/issues/327
 export const rfc327 = () => {
   const semanticFormat = /^(fix|feat|build|chore|ci|docs|style|refactor|perf|test|revert)(?:\(.+\))?!?:.+$/
@@ -227,11 +227,16 @@ export const rfc327 = () => {
   const pr = danger.github.pr
   const repoName = pr.base.repo.name
 
-  const SUPPORTED_REPOS = ["eigen", "force", "palette", "peril-settings", "volt", "volt-v2"]
+  const EXCLUDED_REPOS = ["example-excluded-repo"]
 
-  if (SUPPORTED_REPOS.includes(repoName) && !semanticFormat.test(pr.title) && pr.title !== "Deploy") {
-    return markdown(
-      "Hi there! :wave:\n\nWe're trialing semantic commit formatting which has not been detected in your PR title.\n\nRefer to README#327 and [Conventional Commits](https://www.conventionalcommits.org) for PR/commit formatting guidelines."
+  if (EXCLUDED_REPOS.includes(repoName)) {
+    console.log("This repo is opting out of conventional commits for time being.")
+    return
+  }
+
+  if (!semanticFormat.test(pr.title) && pr.title !== "Deploy") {
+    fail(
+      "Hi there! :wave:\n\nWe use conventional commit formatting which has not been detected in your PRs title.\n\nRefer to README#327 and [Conventional Commits](https://www.conventionalcommits.org) for PR/commit formatting guidelines."
     )
   }
 }

--- a/tests/rfc_327.test.ts
+++ b/tests/rfc_327.test.ts
@@ -21,7 +21,7 @@ describe("rfc327", () => {
     dm.fail = jest.fn()
   })
 
-  describe("when it is an exluded repo", () => {
+  describe("when it is an excluded repo", () => {
     it("does nothing", async () => {
       dm.danger.github.pr.base.repo.name = "example-excluded-repo"
       await rfc327()

--- a/tests/rfc_327.test.ts
+++ b/tests/rfc_327.test.ts
@@ -21,6 +21,14 @@ describe("rfc327", () => {
     dm.markdown = jest.fn()
   })
 
+  describe("when it is not a supported repo", () => {
+    it("does nothing", async () => {
+      dm.danger.github.pr.base.repo.name = "unsupported"
+      await rfc327()
+      expect(dm.markdown).not.toHaveBeenCalled()
+    })
+  })
+
   describe("when a PR title matches semantic formatting", () => {
     it("does nothing", async () => {
       dm.danger.github.pr.title = "feat: add awesome new feature"

--- a/tests/rfc_327.test.ts
+++ b/tests/rfc_327.test.ts
@@ -18,14 +18,14 @@ describe("rfc327", () => {
         },
       },
     }
-    dm.markdown = jest.fn()
+    dm.fail = jest.fn()
   })
 
-  describe("when it is not a supported repo", () => {
+  describe("when it is an exluded repo", () => {
     it("does nothing", async () => {
-      dm.danger.github.pr.base.repo.name = "unsupported"
+      dm.danger.github.pr.base.repo.name = "example-excluded-repo"
       await rfc327()
-      expect(dm.markdown).not.toHaveBeenCalled()
+      expect(dm.fail).not.toHaveBeenCalled()
     })
   })
 
@@ -33,30 +33,30 @@ describe("rfc327", () => {
     it("does nothing", async () => {
       dm.danger.github.pr.title = "feat: add awesome new feature"
       await rfc327()
-      expect(dm.markdown).not.toHaveBeenCalled()
+      expect(dm.fail).not.toHaveBeenCalled()
 
       // Includes optional scope
       dm.danger.github.pr.title = "fix(scope): add awesome new feature"
       await rfc327()
-      expect(dm.markdown).not.toHaveBeenCalled()
+      expect(dm.fail).not.toHaveBeenCalled()
 
       // Accepts breaking change signifier
       dm.danger.github.pr.title = "feat(CX-134): some breaking change"
       await rfc327()
-      expect(dm.markdown).not.toHaveBeenCalled()
+      expect(dm.fail).not.toHaveBeenCalled()
 
       // Accepts breaking change signifier
       dm.danger.github.pr.title = "chore(Auctions): some small task"
       await rfc327()
-      expect(dm.markdown).not.toHaveBeenCalled()
+      expect(dm.fail).not.toHaveBeenCalled()
     })
   })
 
   describe("when a PR title does not match semantic formatting", () => {
-    it("warns the PR author and links to the RFC", async () => {
+    it("fails the PR and links to the RFC", async () => {
       dm.danger.github.pr.title = "Does not match semantic formatting"
       await rfc327()
-      expect(dm.markdown).toHaveBeenCalled()
+      expect(dm.fail).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Makes our conventional commits rule more forceful:
- apply across all repos - excluded repos added if we need exceptions
- fail prs rather than nudge