### PR TITLE
feat: exclude wip prs from conventional commit check

### DIFF
--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -224,7 +224,7 @@ export const deploySummary = async () => {
 export const rfc327 = () => {
   const semanticFormat = /^(fix|feat|build|chore|ci|docs|style|refactor|perf|test|revert)(?:\(.+\))?!?:.+$/
 
-  const wipFormat = /^(wip|\[wip\]|do not merge|\[do not merge\]|draft|\[draft\])(?:\(.+\))?!?:.+$/i
+  const wipFormat = /^[\[\(]?(wip|do not merge|draft)[\]\)]?.*$/i
 
   const pr = danger.github.pr
   const repoName = pr.base.repo.name

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -224,7 +224,7 @@ export const deploySummary = async () => {
 export const rfc327 = () => {
   const semanticFormat = /^(fix|feat|build|chore|ci|docs|style|refactor|perf|test|revert)(?:\(.+\))?!?:.+$/
 
-  const wipFormat = /^(wip|WIP|do not merge|DO NOT MERGE|\[DO NOT MERGE\])(?:\(.+\))?!?:.+$/i
+  const wipFormat = /^(wip|\[wip\]|do not merge|\[do not merge\])(?:\(.+\))?!?:.+$/i
 
   const pr = danger.github.pr
   const repoName = pr.base.repo.name

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -224,7 +224,7 @@ export const deploySummary = async () => {
 export const rfc327 = () => {
   const semanticFormat = /^(fix|feat|build|chore|ci|docs|style|refactor|perf|test|revert)(?:\(.+\))?!?:.+$/
 
-  const wipFormat = /^(wip|\[wip\]|do not merge|\[do not merge\])(?:\(.+\))?!?:.+$/i
+  const wipFormat = /^(wip|\[wip\]|do not merge|\[do not merge\]|draft|\[draft\])(?:\(.+\))?!?:.+$/i
 
   const pr = danger.github.pr
   const repoName = pr.base.repo.name

--- a/org/allPRs.ts
+++ b/org/allPRs.ts
@@ -224,6 +224,8 @@ export const deploySummary = async () => {
 export const rfc327 = () => {
   const semanticFormat = /^(fix|feat|build|chore|ci|docs|style|refactor|perf|test|revert)(?:\(.+\))?!?:.+$/
 
+  const wipFormat = /^(wip|WIP|do not merge|DO NOT MERGE|\[DO NOT MERGE\])(?:\(.+\))?!?:.+$/i
+
   const pr = danger.github.pr
   const repoName = pr.base.repo.name
 
@@ -231,6 +233,11 @@ export const rfc327 = () => {
 
   if (EXCLUDED_REPOS.includes(repoName)) {
     console.log("This repo is opting out of conventional commits for time being.")
+    return
+  }
+
+  if (wipFormat.test(pr.title)) {
+    console.log("This PR is a WIP, so skipping the check.")
     return
   }
 

--- a/tests/rfc_327.test.ts
+++ b/tests/rfc_327.test.ts
@@ -46,6 +46,14 @@ describe("rfc327", () => {
       dm.danger.github.pr.title = "do not merge: test pr"
       await rfc327()
       expect(dm.fail).not.toHaveBeenCalled()
+
+      dm.danger.github.pr.title = "draft: test pr"
+      await rfc327()
+      expect(dm.fail).not.toHaveBeenCalled()
+
+      dm.danger.github.pr.title = "[DRAFT]: test pr"
+      await rfc327()
+      expect(dm.fail).not.toHaveBeenCalled()
     })
   })
 

--- a/tests/rfc_327.test.ts
+++ b/tests/rfc_327.test.ts
@@ -35,6 +35,10 @@ describe("rfc327", () => {
       await rfc327()
       expect(dm.fail).not.toHaveBeenCalled()
 
+      dm.danger.github.pr.title = "[WIP]: test pr"
+      await rfc327()
+      expect(dm.fail).not.toHaveBeenCalled()
+
       dm.danger.github.pr.title = "[DO NOT MERGE]: test pr"
       await rfc327()
       expect(dm.fail).not.toHaveBeenCalled()

--- a/tests/rfc_327.test.ts
+++ b/tests/rfc_327.test.ts
@@ -29,6 +29,22 @@ describe("rfc327", () => {
     })
   })
 
+  describe("when the PR title is a WIP", () => {
+    it("does nothing", async () => {
+      dm.danger.github.pr.title = "wip: do not merge"
+      await rfc327()
+      expect(dm.fail).not.toHaveBeenCalled()
+
+      dm.danger.github.pr.title = "[DO NOT MERGE]: test pr"
+      await rfc327()
+      expect(dm.fail).not.toHaveBeenCalled()
+
+      dm.danger.github.pr.title = "do not merge: test pr"
+      await rfc327()
+      expect(dm.fail).not.toHaveBeenCalled()
+    })
+  })
+
   describe("when a PR title matches semantic formatting", () => {
     it("does nothing", async () => {
       dm.danger.github.pr.title = "feat: add awesome new feature"


### PR DESCRIPTION
This has been bothering me on my prs: https://github.com/artsy/gravity/pull/18001

Just adds an exception for check for common wip prefixes. 