### PR TITLE
fix: do not alert on closed RFC issues

### DIFF
--- a/org/rfc/scheduleRFCsForLabels.ts
+++ b/org/rfc/scheduleRFCsForLabels.ts
@@ -25,8 +25,8 @@ export default async (issues: Issues) => {
     ],
   })
 
-  const rfc = issue.labels.find(l => l.name === "RFC")
-  if (rfc) {
+  const rfc = issue.labels.find((l) => l.name === "RFC")
+  if (rfc && issue.state === "open") {
     console.log("Triggering slack notifications")
 
     await peril.runTask("slack-dev-channel", "in 5 minutes", slackify("🎉: A new RFC has been published."))

--- a/tests/rfc_40.test.ts
+++ b/tests/rfc_40.test.ts
@@ -33,7 +33,7 @@ it("ignores issues which aren't RFCs", async () => {
   expect(danger.github.utils.createOrAddLabel).not.toBeCalled()
 })
 
-it("Triggers tasks when RFC is in the title", async () => {
+it("Triggers tasks when RFC is in the title and the issue is open", async () => {
   const issues: any = {
     repository: {
       owner: {
@@ -62,6 +62,32 @@ it("Triggers tasks when RFC is in the title", async () => {
   })
 })
 
+it("does not trigger tasks when RFC is in the title and the issue is closed", async () => {
+  const issues: any = {
+    repository: {
+      owner: {
+        login: "org",
+      },
+      name: "repo",
+    },
+    issue: {
+      title: "[RFC] Let's make a change",
+      html_url: "123",
+      number: 123,
+      state: "closed",
+      user: {
+        login: "orta",
+        avatar_url: "https://123.com",
+      },
+    },
+  }
+
+  await addRFCLabel(issues)
+
+  expect(peril.runTask).not.toBeCalled()
+  expect(danger.github.utils.createOrAddLabel).not.toBeCalled()
+})
+
 it("Triggers tasks when RFC is in the labels", async () => {
   const issues: any = {
     repository: {
@@ -73,6 +99,7 @@ it("Triggers tasks when RFC is in the labels", async () => {
     issue: {
       title: "[RFC] Let's make a change",
       html_url: "123",
+      state: "open",
       number: 123,
       labels: [{ name: "RFC" }],
       user: {


### PR DESCRIPTION
**Context:**

Over the past few weeks, we have been receiving a reminder about closing an already closed issue:

<img width="634" alt="Screenshot 2025-06-30 at 09 40 13" src="https://github.com/user-attachments/assets/e39100f8-5449-46f5-910f-b3e390d89ac9" />

This PR fixes that by making sure to check first if the issue is still open or not. We do something similar here
https://github.com/artsy/peril-settings/blob/e667b7ecc6ab167e5631d0fd981bf69216b5fd5a/org/rfc/scheduleRFCsForLabels.ts#L29 