### PR TITLE
refactor: remove unused or migrated peril settings

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -16,25 +16,5 @@
     "issue_comment": "org/markAsMergeOnGreen.ts",
     "status.success": "org/mergeOnGreen.ts",
     "pull_request_review": "org/markAsMergeOnGreen.ts"
-  },
-  "repos": {
-    "artsy/metaphysics": {
-      "pull_request": "peril/compareForceSchema.ts"
-    },
-    "artsy/reaction": {
-      "pull_request": "danger/pr.ts"
-    },
-    "artsy/positron": {
-      "pull_request": "dangerfile.ts"
-    },
-    "artsy/exchange": {
-      "pull_request": "dangerfile.ts"
-    },
-    "artsy/volt": {
-      "pull_request": "dangerfile.ts"
-    },
-    "artsy/peril-settings": {
-      "pull_request": "dangerfile.ts"
-    }
   }
 }


### PR DESCRIPTION
Peril and Github Actions on PRs have been running in parallel for over a week now and I haven't heard any complaints, so I think we're good to remove Peril running the same dangerfiles in **metaphysics**, **volt**, and **exchange**. We checked the other repos in the list and they were just running checks that Peril is already doing anyway, so we didn't migrate anything for those.